### PR TITLE
feat: update skills for Core 3 SDK patterns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
     "email": "support@clerk.com"
   },
   "metadata": {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "Complete Clerk authentication toolkit with router for setup, custom UI, Next.js patterns, organizations, webhooks, and testing"
   },
   "plugins": [
     {
       "name": "clerk",
       "description": "Clerk authentication router - automatically routes to the right skill based on your task",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -29,7 +29,7 @@
     {
       "name": "clerk-setup",
       "description": "Add Clerk authentication to any project by following the official quickstart guides",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -43,8 +43,8 @@
     },
     {
       "name": "clerk-custom-ui",
-      "description": "Build custom sign-in/sign-up flows and customize component appearance",
-      "version": "1.0.0",
+      "description": "Custom authentication flows (useSignIn, useSignUp hooks) and component appearance customization",
+      "version": "2.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -54,12 +54,12 @@
       "repository": "https://github.com/clerk/skills",
       "license": "MIT",
       "category": "authentication",
-      "keywords": ["auth", "custom-ui", "appearance", "sign-in", "sign-up"]
+      "keywords": ["auth", "custom-ui", "appearance", "sign-in", "sign-up", "useSignIn", "useSignUp", "custom-flows", "themes"]
     },
     {
       "name": "clerk-nextjs-patterns",
       "description": "Advanced Next.js patterns - middleware, Server Actions, caching with Clerk",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -74,7 +74,7 @@
     {
       "name": "clerk-orgs",
       "description": "Clerk Organizations for B2B SaaS - create multi-tenant apps with org switching, role-based access, verified domains, and enterprise SSO. Use for team workspaces, RBAC, org-based routing, member management.",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
     "email": "support@clerk.com"
   },
   "metadata": {
-    "version": "2.0.0",
+    "version": "1.0.0",
     "description": "Complete Clerk authentication toolkit with router for setup, custom UI, Next.js patterns, organizations, webhooks, and testing"
   },
   "plugins": [
     {
       "name": "clerk",
       "description": "Clerk authentication router - automatically routes to the right skill based on your task",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -29,7 +29,7 @@
     {
       "name": "clerk-setup",
       "description": "Add Clerk authentication to any project by following the official quickstart guides",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -44,7 +44,7 @@
     {
       "name": "clerk-custom-ui",
       "description": "Custom authentication flows (useSignIn, useSignUp hooks) and component appearance customization",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -59,7 +59,7 @@
     {
       "name": "clerk-nextjs-patterns",
       "description": "Advanced Next.js patterns - middleware, Server Actions, caching with Clerk",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"
@@ -74,7 +74,7 @@
     {
       "name": "clerk-orgs",
       "description": "Clerk Organizations for B2B SaaS - create multi-tenant apps with org switching, role-based access, verified domains, and enterprise SSO. Use for team workspaces, RBAC, org-based routing, member management.",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "author": {
         "name": "Clerk",
         "email": "support@clerk.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ skills/
 │   └── clerk.md              # /clerk slash command workflow
 ├── skills/
 │   ├── setup/                # Framework setup & basic auth
-│   ├── custom-ui/            # Custom sign-in/up components
+│   ├── custom-ui/            # Custom sign-in/up flows & appearance
+│   │   ├── core-2/           # Core 2 custom flow references
+│   │   └── core-3/           # Current custom flow references
 │   ├── managing-orgs/        # B2B multi-tenant organizations
 │   ├── nextjs-patterns/      # Advanced Next.js patterns
 │   ├── syncing-users/        # Webhook → database sync
@@ -103,12 +105,14 @@ Use these levels to prioritize guidance:
 ```typescript
 // Server Components (Next.js App Router)
 import { auth } from '@clerk/nextjs/server';
-const { userId } = await auth();  // MUST await
+const { isAuthenticated, userId } = await auth();  // MUST await
 
 // Client Components
 import { useAuth } from '@clerk/nextjs';
-const { userId } = useAuth();  // Hook, no await
+const { isAuthenticated, userId } = useAuth();  // Hook, no await
 ```
+
+> **Core 2:** `isAuthenticated` is not available. Check `!!userId` instead.
 
 ### Framework Detection
 
@@ -124,7 +128,7 @@ Check for these files to detect the framework:
 2. **Wrong import path** - Use `@clerk/nextjs/server` for server code
 3. **Middleware matcher** - Must include API routes: `matcher: ['/((?!.*\\..*|_next).*)', '/']`
 4. **Environment variables** - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` must be public
-5. **ClerkProvider missing** - Must wrap app in root layout
+5. **ClerkProvider missing** - Must wrap app in root layout, inside `<body>` in Next.js (Core 2: could wrap `<html>`)
 
 ## Quality Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@ skills/
 │   ├── custom-ui/            # Custom sign-in/up flows & appearance
 │   │   ├── core-2/           # Core 2 custom flow references
 │   │   └── core-3/           # Current custom flow references
-│   ├── managing-orgs/        # B2B multi-tenant organizations
+│   ├── orgs/                 # B2B multi-tenant organizations
 │   ├── nextjs-patterns/      # Advanced Next.js patterns
-│   ├── syncing-users/        # Webhook → database sync
+│   ├── webhooks/             # Webhook → database sync
 │   └── testing/              # E2E testing setup
 └── README.md                 # User-facing documentation
 ```
@@ -31,8 +31,8 @@ User Request
     │
     ├─ "Add authentication" → setup/
     ├─ "Custom sign-in UI"  → custom-ui/
-    ├─ "Organizations/RBAC" → managing-orgs/
-    ├─ "Sync users to DB"   → syncing-users/
+    ├─ "Organizations/RBAC" → orgs/
+    ├─ "Sync users to DB"   → webhooks/
     ├─ "Write tests"        → testing/
     └─ "Next.js patterns"   → nextjs-patterns/
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ const { isAuthenticated, userId } = await auth();  // MUST await
 
 // Client Components
 import { useAuth } from '@clerk/nextjs';
-const { isAuthenticated, userId } = useAuth();  // Hook, no await
+const { isSignedIn, userId } = useAuth();  // Hook, no await
 ```
 
 > **Core 2:** `isAuthenticated` is not available. Check `!!userId` instead.

--- a/commands/clerk.md
+++ b/commands/clerk.md
@@ -38,10 +38,10 @@ Based on task type, load the appropriate skill:
 | Task | Skill | Files to Read |
 |------|-------|---------------|
 | Add auth | `setup/` | SKILL.md |
-| Custom UI | `customizing-auth-ui/` | SKILL.md + core-2/ or core-3/ references |
-| Sync users | `syncing-users/` | SKILL.md |
-| Testing | `testing-auth/` | SKILL.md |
-| Multi-tenant | `managing-orgs/` | SKILL.md |
+| Custom UI | `custom-ui/` | SKILL.md + core-2/ or core-3/ references |
+| Sync users | `webhooks/` | SKILL.md |
+| Testing | `testing/` | SKILL.md |
+| Multi-tenant | `orgs/` | SKILL.md |
 | Next.js patterns | `nextjs-patterns/` | SKILL.md + relevant reference |
 
 ### Step 5: Execute task

--- a/commands/clerk.md
+++ b/commands/clerk.md
@@ -38,7 +38,7 @@ Based on task type, load the appropriate skill:
 | Task | Skill | Files to Read |
 |------|-------|---------------|
 | Add auth | `setup/` | SKILL.md |
-| Custom UI | `customizing-auth-ui/` | SKILL.md |
+| Custom UI | `customizing-auth-ui/` | SKILL.md + core-2/ or core-3/ references |
 | Sync users | `syncing-users/` | SKILL.md |
 | Testing | `testing-auth/` | SKILL.md |
 | Multi-tenant | `managing-orgs/` | SKILL.md |

--- a/skills/clerk/.claude-plugin/plugin.json
+++ b/skills/clerk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clerk",
   "description": "Clerk authentication router - automatically routes to the right skill based on your task",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Clerk",
     "email": "support@clerk.com"

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -5,7 +5,23 @@ description: Clerk authentication router. Use when user asks about adding authen
 
 # Clerk Skills Router
 
-Based on what you're trying to do, here's the right skill to use:
+## Version Detection
+
+Check `package.json` to determine the Clerk SDK version. This determines which patterns to use:
+
+| Package | Core 2 (LTS until Jan 2027) | Current |
+|---------|----------------------------|---------|
+| `@clerk/nextjs` | v5–v6 | v7+ |
+| `@clerk/react` or `@clerk/clerk-react` | v5–v6 | v7+ |
+| `@clerk/expo` or `@clerk/clerk-expo` | v1–v2 | v3+ |
+| `@clerk/react-router` | v1–v2 | v3+ |
+| `@clerk/tanstack-react-start` | < v0.26.0 | v0.26.0+ |
+
+**Default to current** if the version is unclear or the project is new. Core 2 packages use `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix); current packages use `@clerk/react` and `@clerk/expo`.
+
+All skills are written for the current SDK. When something differs in Core 2, it's noted inline with `> **Core 2:**` callouts. The exception is `clerk-custom-ui`, which has separate `core-2/` and `core-3/` directories for custom flow hooks since those APIs are entirely different between versions.
+
+---
 
 ## By Task
 
@@ -15,9 +31,9 @@ Based on what you're trying to do, here's the right skill to use:
 - Migration from other auth providers
 
 **Custom sign-in/sign-up UI** → Use `clerk-custom-ui`
-- Custom authentication flows
-- Appearance and styling
-- OAuth, magic links, passkeys, MFA
+- Custom authentication flows with `useSignIn` / `useSignUp` hooks
+- Appearance and styling (themes, colors, layout)
+- `<Show>` component for conditional rendering
 
 **Advanced Next.js patterns** → Use `clerk-nextjs-patterns`
 - Server vs Client auth APIs
@@ -45,7 +61,7 @@ Based on what you're trying to do, here's the right skill to use:
 
 If you know your task, you can directly access:
 - `/clerk-setup` - Framework setup
-- `/clerk-custom-ui` - Custom flows
+- `/clerk-custom-ui` - Custom flows & appearance
 - `/clerk-nextjs-patterns` - Next.js patterns
 - `/clerk-orgs` - Organizations
 - `/clerk-webhooks` - Webhooks

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -19,7 +19,7 @@ Check `package.json` to determine the Clerk SDK version. This determines which p
 
 **Default to current** if the version is unclear or the project is new. Core 2 packages use `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix); current packages use `@clerk/react` and `@clerk/expo`.
 
-All skills are written for the current SDK. When something differs in Core 2, it's noted inline with `> **Core 2:**` callouts. The exception is `clerk-custom-ui`, which has separate `core-2/` and `core-3/` directories for custom flow hooks since those APIs are entirely different between versions.
+All skills are written for the current SDK. When something differs in Core 2, it's noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts. The exception is `clerk-custom-ui`, which has separate `core-2/` and `core-3/` directories for custom flow hooks since those APIs are entirely different between versions.
 
 ---
 

--- a/skills/custom-ui/.claude-plugin/plugin.json
+++ b/skills/custom-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clerk-custom-ui",
-  "description": "Build custom sign-in/sign-up flows and customize component appearance. Use for custom auth flows, appearance styling, non-standard patterns.",
-  "version": "1.0.0",
+  "description": "Custom authentication flows (useSignIn, useSignUp hooks) and component appearance customization. Use for custom sign-in/sign-up flows, themes, appearance styling, branding.",
+  "version": "2.0.0",
   "author": {
     "name": "Clerk",
     "email": "support@clerk.com"
@@ -9,6 +9,6 @@
   "license": "MIT",
   "homepage": "https://clerk.com/docs",
   "repository": "https://github.com/clerk/skills",
-  "keywords": ["auth", "custom-ui", "appearance", "sign-in", "sign-up"],
+  "keywords": ["auth", "custom-ui", "appearance", "sign-in", "sign-up", "useSignIn", "useSignUp", "custom-flows", "themes"],
   "category": "authentication"
 }

--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 # Custom UI
 
 > **Prerequisite**: Ensure `ClerkProvider` wraps your app. See `setup/`.
+>
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. This determines which custom flow references to use below.
 
 This skill covers two areas:
 1. **Custom authentication flows** — build your own sign-in/sign-up UI with hooks

--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -60,7 +60,7 @@ Appearance customization applies to both Core 2 and the current SDK.
 />
 ```
 
-> **Core 2:** The `options` property was named `layout`. Use `layout: { logoImageUrl: '...', socialButtonsVariant: '...' }` instead of `options`.
+> **Core 2 ONLY (skip if current SDK):** The `options` property was named `layout`. Use `layout: { logoImageUrl: '...', socialButtonsVariant: '...' }` instead of `options`.
 
 ### variables (colors, typography, borders)
 
@@ -72,7 +72,7 @@ Appearance customization applies to both Core 2 and the current SDK.
 
 **Opacity change:** `colorRing` and `colorModalBackdrop` now render at full opacity. Use explicit `rgba()` values if you need transparency.
 
-> **Core 2:** `colorRing` and `colorModalBackdrop` rendered at 15% opacity by default.
+> **Core 2 ONLY (skip if current SDK):** `colorRing` and `colorModalBackdrop` rendered at 15% opacity by default.
 
 ### options (structure, logo, social buttons)
 
@@ -83,7 +83,7 @@ Appearance customization applies to both Core 2 and the current SDK.
 | `socialButtonsPlacement` | `'top'` \| `'bottom'` |
 | `showOptionalFields` | Show optional fields (default: `false`) |
 
-> **Core 2:** This property is called `layout`, not `options`. Also, `showOptionalFields` defaulted to `true`.
+> **Core 2 ONLY (skip if current SDK):** This property is called `layout`, not `options`. Also, `showOptionalFields` defaulted to `true`.
 
 ### Themes
 
@@ -99,7 +99,7 @@ import { dark } from '@clerk/ui/themes'
 <ClerkProvider appearance={{ theme: dark }} />
 ```
 
-> **Core 2:** Themes are imported from `@clerk/themes` (install `@clerk/themes` instead of `@clerk/ui`). Example: `import { dark } from '@clerk/themes'`.
+> **Core 2 ONLY (skip if current SDK):** Themes are imported from `@clerk/themes` (install `@clerk/themes` instead of `@clerk/ui`). Example: `import { dark } from '@clerk/themes'`.
 
 **Theme stacking** — pass an array where the last theme takes precedence:
 
@@ -129,7 +129,7 @@ Also import shadcn CSS in your global styles:
 @import '@clerk/ui/themes/shadcn.css';
 ```
 
-> **Core 2:** Import from `@clerk/themes` and `@clerk/themes/shadcn.css`:
+> **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css`:
 > ```typescript
 > import { shadcn } from '@clerk/themes'
 > ```

--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -1,29 +1,47 @@
 ---
 name: clerk-custom-ui
-description: Customize Clerk component appearance - themes, layout, colors, fonts, CSS. Use for appearance styling, visual customization, branding.
+description: Custom authentication flows and component appearance - hooks (useSignIn, useSignUp), themes, colors, fonts, CSS. Use for custom sign-in/sign-up flows, appearance styling, visual customization, branding.
 allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
-# Component Customization
+# Custom UI
 
 > **Prerequisite**: Ensure `ClerkProvider` wraps your app. See `setup/`.
 
-## Component Customization Options
+This skill covers two areas:
+1. **Custom authentication flows** — build your own sign-in/sign-up UI with hooks
+2. **Appearance customization** — theme, style, and brand Clerk's pre-built components
+
+## Custom Flow References
+
+| Task | Core 2 | Current |
+|------|--------|---------|
+| Custom sign-in (useSignIn) | `core-2/custom-sign-in.md` | `core-3/custom-sign-in.md` |
+| Custom sign-up (useSignUp) | `core-2/custom-sign-up.md` | `core-3/custom-sign-up.md` |
+| `<Show>` component | *(use `<SignedIn>`, `<SignedOut>`, `<Protect>`)* | `core-3/show-component.md` |
+
+---
+
+## Appearance Customization
+
+Appearance customization applies to both Core 2 and the current SDK.
+
+### Component Customization Options
 
 | Task | Documentation |
 |------|---------------|
 | Appearance prop overview | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/overview |
-| Layout (structure, logo, buttons) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/layout |
+| Options (structure, logo, buttons) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/layout |
 | Themes (pre-built dark/light) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes |
 | Variables (colors, fonts, spacing) | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/variables |
 | CAPTCHA configuration | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/captcha |
 | Bring your own CSS | https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/bring-your-own-css |
 
-## Appearance Pattern
+### Appearance Pattern
 
 ```typescript
 <SignIn
@@ -32,13 +50,15 @@ metadata:
       colorPrimary: '#0000ff',
       borderRadius: '0.5rem',
     },
-    layout: {
+    options: {
       logoImageUrl: '/logo.png',
       socialButtonsVariant: 'iconButton',
     },
   }}
 />
 ```
+
+> **Core 2:** The `options` property was named `layout`. Use `layout: { logoImageUrl: '...', socialButtonsVariant: '...' }` instead of `options`.
 
 ### variables (colors, typography, borders)
 
@@ -48,45 +68,86 @@ metadata:
 | `colorBackground` | Background color |
 | `borderRadius` | Border radius (default: `0.375rem`) |
 
-### layout (structure, logo, social buttons)
+**Opacity change:** `colorRing` and `colorModalBackdrop` now render at full opacity. Use explicit `rgba()` values if you need transparency.
+
+> **Core 2:** `colorRing` and `colorModalBackdrop` rendered at 15% opacity by default.
+
+### options (structure, logo, social buttons)
 
 | Property | Description |
 |----------|-------------|
 | `logoImageUrl` | URL to custom logo |
 | `socialButtonsVariant` | `'blockButton'` \| `'iconButton'` \| `'auto'` |
 | `socialButtonsPlacement` | `'top'` \| `'bottom'` |
+| `showOptionalFields` | Show optional fields (default: `false`) |
 
-## shadcn Theme
+> **Core 2:** This property is called `layout`, not `options`. Also, `showOptionalFields` defaulted to `true`.
 
-**If the project has `components.json`** (shadcn/ui installed), use the shadcn theme:
+### Themes
+
+Install themes from `@clerk/ui`:
+
+```bash
+npm install @clerk/ui
+```
 
 ```typescript
-import { shadcn } from '@clerk/themes'
+import { dark } from '@clerk/ui/themes'
 
-<ClerkProvider
-  appearance={{
-    theme: shadcn,
-  }}
-/>
+<ClerkProvider appearance={{ theme: dark }} />
 ```
 
-Also import shadcn CSS in your global.css:
+> **Core 2:** Themes are imported from `@clerk/themes` (install `@clerk/themes` instead of `@clerk/ui`). Example: `import { dark } from '@clerk/themes'`.
+
+**Theme stacking** — pass an array where the last theme takes precedence:
+
+```typescript
+import { dark, neobrutalism } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: [dark, neobrutalism] }} />
+```
+
+**CSS `color-scheme` support** — the default theme respects the CSS `color-scheme` property for automatic light/dark mode toggling.
+
+**Available themes:** `dark`, `neobrutalism`, `shadcn`, `simple`
+
+#### shadcn Theme
+
+If the project has `components.json` (shadcn/ui installed), use the shadcn theme:
+
+```typescript
+import { shadcn } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: shadcn }} />
+```
+
+Also import shadcn CSS in your global styles:
 ```css
 @import 'tailwindcss';
-@import '@clerk/themes/shadcn.css';
+@import '@clerk/ui/themes/shadcn.css';
 ```
+
+> **Core 2:** Import from `@clerk/themes` and `@clerk/themes/shadcn.css`:
+> ```typescript
+> import { shadcn } from '@clerk/themes'
+> ```
+> ```css
+> @import '@clerk/themes/shadcn.css';
+> ```
+
 ## Workflow
 
-1. Identify customization needs (colors, layout, theme, CSS)
-2. WebFetch the appropriate documentation from table above
-3. Follow official code examples from the docs
-4. Apply appearance prop to your Clerk components
+1. Identify customization needs (custom flow or appearance)
+2. For custom flows: check SDK version → read appropriate `core-2/` or `core-3/` reference
+3. For appearance: WebFetch the appropriate documentation from table above
+4. Apply appearance prop to your Clerk components or build custom flow with hooks
 
 ## Common Pitfalls
 
 | Issue | Solution |
 |-------|----------|
 | Colors not applying | Use `colorPrimary` not `primaryColor` |
-| Logo not showing | Put `logoImageUrl` inside `layout: {}` |
-| Social buttons wrong | Add `socialButtonsVariant: 'iconButton'` in `layout` |
+| Logo not showing | Put `logoImageUrl` inside `options: {}` (or `layout: {}` in Core 2) |
+| Social buttons wrong | Add `socialButtonsVariant: 'iconButton'` in `options` (or `layout` in Core 2) |
 | Styling not working | Use appearance prop, not direct CSS (unless with bring-your-own-css) |
+| Hook returns different shape | Check SDK version — Core 2 and current have completely different `useSignIn`/`useSignUp` APIs |

--- a/skills/custom-ui/core-2/custom-sign-in.md
+++ b/skills/custom-ui/core-2/custom-sign-in.md
@@ -1,0 +1,224 @@
+# Custom Sign-In Flow (Core 2)
+
+> This document covers the **older SDK** (`@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, `@clerk/clerk-expo` v1–v2). For the current SDK, see `core-3/custom-sign-in.md`.
+
+Build a custom sign-in experience using the `useSignIn()` hook.
+
+## Hook API
+
+```typescript
+import { useSignIn } from '@clerk/nextjs' // or @clerk/clerk-react, @clerk/clerk-expo
+
+const { signIn, isLoaded, setActive } = useSignIn()
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `signIn` | `SignIn` | Sign-in object with methods |
+| `isLoaded` | `boolean` | Whether the hook has loaded |
+| `setActive` | `(params) => Promise` | Sets the active session |
+
+## Sign-In Flow
+
+### 1. Create Sign-In
+
+```typescript
+const result = await signIn.create({
+  identifier: 'user@example.com',
+  password: 'securePassword123',
+})
+```
+
+### 2. First Factor Verification
+
+If additional verification is needed (email code, phone code):
+
+```typescript
+// Prepare first factor
+await signIn.prepareFirstFactor({
+  strategy: 'email_code', // or 'phone_code'
+})
+
+// Attempt first factor
+const result = await signIn.attemptFirstFactor({
+  strategy: 'email_code',
+  code: '123456',
+})
+```
+
+### 3. Second Factor (MFA)
+
+If the sign-in requires MFA:
+
+```typescript
+// Prepare second factor
+await signIn.prepareSecondFactor({
+  strategy: 'email_code', // or 'phone_code'
+})
+
+// Attempt second factor
+const result = await signIn.attemptSecondFactor({
+  strategy: 'totp', // or 'email_code', 'phone_code', 'backup_code'
+  code: '123456',
+})
+```
+
+### 4. Finalize
+
+Set the active session after successful authentication:
+
+```typescript
+await setActive({ session: signIn.createdSessionId })
+```
+
+### Password Reset
+
+```typescript
+// 1. Start reset flow
+await signIn.create({ strategy: 'reset_password_email_code', identifier: 'user@example.com' })
+
+// or prepare after initial create:
+await signIn.prepareFirstFactor({ strategy: 'reset_password_email_code' })
+
+// 2. Verify reset code
+await signIn.attemptFirstFactor({ strategy: 'reset_password_email_code', code: '123456' })
+
+// 3. Set new password
+await signIn.resetPassword({ password: 'newSecurePassword123' })
+```
+
+### SSO (OAuth)
+
+```typescript
+await signIn.authenticateWithRedirect({
+  strategy: 'oauth_google', // or 'oauth_github', etc.
+  redirectUrl: '/sso-callback',
+  redirectUrlComplete: '/',
+})
+```
+
+## Error Handling
+
+Use try/catch with `isClerkAPIResponseError()`:
+
+```typescript
+import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
+
+try {
+  await signIn.create({ identifier, password })
+} catch (err) {
+  if (isClerkAPIResponseError(err)) {
+    err.errors.forEach((e) => {
+      console.log(e.code)        // e.g. 'form_identifier_not_found'
+      console.log(e.message)     // Human-readable message
+      console.log(e.longMessage) // Detailed message
+    })
+  }
+}
+```
+
+## Complete Example: Email/Password with MFA
+
+```tsx
+'use client'
+import { useState } from 'react'
+import { useSignIn } from '@clerk/nextjs'
+import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
+import { useRouter } from 'next/navigation'
+
+export default function SignInPage() {
+  const { signIn, isLoaded, setActive } = useSignIn()
+  const router = useRouter()
+
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+  const [mfaCode, setMfaCode] = useState('')
+  const [step, setStep] = useState<'credentials' | 'mfa'>('credentials')
+  const [error, setError] = useState('')
+
+  if (!isLoaded) return <div>Loading...</div>
+
+  async function handleSignIn(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+
+    try {
+      const result = await signIn.create({ identifier, password })
+
+      if (result.status === 'needs_second_factor') {
+        setStep('mfa')
+        return
+      }
+
+      if (result.status === 'complete') {
+        await setActive({ session: result.createdSessionId })
+        router.push('/')
+      }
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || 'Sign in failed')
+      }
+    }
+  }
+
+  async function handleMFA(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+
+    try {
+      const result = await signIn.attemptSecondFactor({
+        strategy: 'totp',
+        code: mfaCode,
+      })
+
+      if (result.status === 'complete') {
+        await setActive({ session: result.createdSessionId })
+        router.push('/')
+      }
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || 'Verification failed')
+      }
+    }
+  }
+
+  if (step === 'mfa') {
+    return (
+      <form onSubmit={handleMFA}>
+        <input
+          type="text"
+          value={mfaCode}
+          onChange={(e) => setMfaCode(e.target.value)}
+          placeholder="Enter MFA code"
+        />
+        {error && <p>{error}</p>}
+        <button type="submit">Verify</button>
+      </form>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSignIn}>
+      <input
+        type="email"
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      {error && <p>{error}</p>}
+      <button type="submit">Sign In</button>
+    </form>
+  )
+}
+```
+
+## Docs
+
+- [Custom sign-in flow](https://clerk.com/docs/custom-flows/overview)
+- [useSignIn() reference](https://clerk.com/docs/references/react/use-sign-in)

--- a/skills/custom-ui/core-2/custom-sign-up.md
+++ b/skills/custom-ui/core-2/custom-sign-up.md
@@ -1,0 +1,190 @@
+# Custom Sign-Up Flow (Core 2)
+
+> This document covers the **older SDK** (`@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, `@clerk/clerk-expo` v1–v2). For the current SDK, see `core-3/custom-sign-up.md`.
+
+Build a custom sign-up experience using the `useSignUp()` hook.
+
+## Hook API
+
+```typescript
+import { useSignUp } from '@clerk/nextjs' // or @clerk/clerk-react, @clerk/clerk-expo
+
+const { signUp, isLoaded, setActive } = useSignUp()
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `signUp` | `SignUp` | Sign-up object with methods |
+| `isLoaded` | `boolean` | Whether the hook has loaded |
+| `setActive` | `(params) => Promise` | Sets the active session |
+
+## Sign-Up Flow
+
+### 1. Create Sign-Up
+
+```typescript
+const result = await signUp.create({
+  emailAddress: 'user@example.com',
+  password: 'securePassword123',
+  firstName: 'Jane',  // optional
+  lastName: 'Doe',    // optional
+})
+```
+
+### 2. Prepare Verification
+
+Send a verification code to the user's email or phone:
+
+```typescript
+await signUp.prepareVerification({
+  strategy: 'email_code', // or 'phone_code', 'email_link'
+})
+```
+
+### 3. Attempt Verification
+
+Verify the code the user received:
+
+```typescript
+const result = await signUp.attemptVerification({
+  strategy: 'email_code',
+  code: '123456',
+})
+```
+
+### 4. Finalize
+
+Set the active session after successful sign-up:
+
+```typescript
+await setActive({ session: signUp.createdSessionId })
+```
+
+### SSO (OAuth)
+
+```typescript
+await signUp.authenticateWithRedirect({
+  strategy: 'oauth_google',
+  redirectUrl: '/sso-callback',
+  redirectUrlComplete: '/',
+})
+```
+
+## Error Handling
+
+Use try/catch with `isClerkAPIResponseError()`:
+
+```typescript
+import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
+
+try {
+  await signUp.create({ emailAddress, password })
+} catch (err) {
+  if (isClerkAPIResponseError(err)) {
+    err.errors.forEach((e) => {
+      console.log(e.code)        // e.g. 'form_password_pwned'
+      console.log(e.message)     // Human-readable message
+      console.log(e.longMessage) // Detailed message
+    })
+  }
+}
+```
+
+## Complete Example: Email/Password with Email Verification
+
+```tsx
+'use client'
+import { useState } from 'react'
+import { useSignUp } from '@clerk/nextjs'
+import { isClerkAPIResponseError } from '@clerk/nextjs/errors'
+import { useRouter } from 'next/navigation'
+
+export default function SignUpPage() {
+  const { signUp, isLoaded, setActive } = useSignUp()
+  const router = useRouter()
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [code, setCode] = useState('')
+  const [step, setStep] = useState<'register' | 'verify'>('register')
+  const [error, setError] = useState('')
+
+  if (!isLoaded) return <div>Loading...</div>
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+
+    try {
+      await signUp.create({ emailAddress: email, password })
+      await signUp.prepareVerification({ strategy: 'email_code' })
+      setStep('verify')
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || 'Sign up failed')
+      }
+    }
+  }
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+
+    try {
+      const result = await signUp.attemptVerification({
+        strategy: 'email_code',
+        code,
+      })
+
+      if (result.status === 'complete') {
+        await setActive({ session: result.createdSessionId })
+        router.push('/')
+      }
+    } catch (err) {
+      if (isClerkAPIResponseError(err)) {
+        setError(err.errors[0]?.message || 'Verification failed')
+      }
+    }
+  }
+
+  if (step === 'verify') {
+    return (
+      <form onSubmit={handleVerify}>
+        <p>Check your email for a verification code.</p>
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="Verification code"
+        />
+        {error && <p>{error}</p>}
+        <button type="submit">Verify Email</button>
+      </form>
+    )
+  }
+
+  return (
+    <form onSubmit={handleRegister}>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      {error && <p>{error}</p>}
+      <button type="submit">Sign Up</button>
+    </form>
+  )
+}
+```
+
+## Docs
+
+- [Custom sign-up flow](https://clerk.com/docs/custom-flows/overview)
+- [useSignUp() reference](https://clerk.com/docs/references/react/use-sign-up)

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -143,8 +143,8 @@ await signIn.finalize({
 })
 ```
 
-- `decorateUrl(path)` — decorates the URL with session info (required)
-- `session?.currentTask` — check for pending session tasks before redirecting
+- `decorateUrl(path)` — decorates the URL with session info (required to support Safari's Intelligent Tracking Prevention). May return an absolute URL.
+- `session.currentTask` — check for pending session tasks before redirecting
 
 ### Reset State
 

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -77,7 +77,9 @@ const { error } = await signIn.phoneCode.verifyCode({ code: '123456' })
 
 ## MFA (Second Factor)
 
-When the sign-in requires a second factor:
+A second factor is required when `signIn.status` is one of:
+- `'needs_second_factor'` — user has MFA enabled (TOTP, backup codes, etc.)
+- `'needs_client_trust'` — new device sign-in without MFA; requires email or phone code verification
 
 ```typescript
 // TOTP (Authenticator app)

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -2,30 +2,6 @@
 
 Build a custom sign-in experience using the `useSignIn()` hook.
 
-> **Core 2:** The `useSignIn()` hook returns a completely different shape in Core 2. If the project uses `@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, or `@clerk/clerk-expo` v1–v2, see `core-2/custom-sign-in.md` instead. Key differences: returns `{ signIn, isLoaded, setActive }`, uses `create()` / `prepareFirstFactor()` / `attemptFirstFactor()` methods, and `setActive({ session: signIn.createdSessionId })` to finalize. Errors use try/catch with `isClerkAPIResponseError()`.
-
-## Quick Reference: Core 2 → Current
-
-| Core 2 | Current |
-|--------|---------|
-| `signIn.create({ identifier, password })` | `signIn.password({ identifier, password })` |
-| `signIn.authenticateWithRedirect({ strategy: 'oauth_google' })` | `signIn.sso({ strategy: 'oauth_google' })` |
-| `signIn.authenticateWithPasskey()` | `signIn.passkey({ flow: 'discoverable' })` |
-| `signIn.prepareFirstFactor({ strategy: 'email_code' })` | `signIn.emailCode.sendCode()` |
-| `signIn.attemptFirstFactor({ strategy: 'email_code', code })` | `signIn.emailCode.verifyCode({ code })` |
-| `signIn.prepareFirstFactor({ strategy: 'phone_code' })` | `signIn.phoneCode.sendCode()` |
-| `signIn.attemptFirstFactor({ strategy: 'phone_code', code })` | `signIn.phoneCode.verifyCode({ code })` |
-| `signIn.prepareSecondFactor({ strategy: 'email_code' })` | `signIn.mfa.sendEmailCode()` |
-| `signIn.attemptSecondFactor({ strategy: 'email_code', code })` | `signIn.mfa.verifyEmailCode({ code })` |
-| `signIn.attemptSecondFactor({ strategy: 'phone_code', code })` | `signIn.mfa.verifyPhoneCode({ code })` |
-| `signIn.attemptSecondFactor({ strategy: 'totp', code })` | `signIn.mfa.verifyTOTP({ code })` |
-| `signIn.attemptSecondFactor({ strategy: 'backup_code', code })` | `signIn.mfa.verifyBackupCode({ code })` |
-| `signIn.prepareFirstFactor({ strategy: 'reset_password_email_code' })` | `signIn.resetPasswordEmailCode.sendCode()` |
-| `signIn.attemptFirstFactor({ strategy: 'reset_password_email_code', code })` | `signIn.resetPasswordEmailCode.verifyCode({ code })` |
-| `signIn.resetPassword({ password })` | `signIn.resetPasswordEmailCode.submitPassword({ password })` |
-| `setActive({ session: signIn.createdSessionId })` | `signIn.finalize({ navigate })` |
-| try/catch with `isClerkAPIResponseError()` | `errors.fields`, `errors.global`, `errors.raw` |
-
 ## Hook API
 
 ```typescript

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -1,0 +1,301 @@
+# Custom Sign-In Flow
+
+Build a custom sign-in experience using the `useSignIn()` hook.
+
+> **Core 2:** The `useSignIn()` hook returns a completely different shape in Core 2. If the project uses `@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, or `@clerk/clerk-expo` v1–v2, see `core-2/custom-sign-in.md` instead. Key differences: returns `{ signIn, isLoaded, setActive }`, uses `create()` / `prepareFirstFactor()` / `attemptFirstFactor()` methods, and `setActive({ session: signIn.createdSessionId })` to finalize. Errors use try/catch with `isClerkAPIResponseError()`.
+
+## Quick Reference: Core 2 → Current
+
+| Core 2 | Current |
+|--------|---------|
+| `signIn.create({ identifier, password })` | `signIn.password({ identifier, password })` |
+| `signIn.authenticateWithRedirect({ strategy: 'oauth_google' })` | `signIn.sso({ strategy: 'oauth_google' })` |
+| `signIn.authenticateWithPasskey()` | `signIn.passkey({ flow: 'discoverable' })` |
+| `signIn.prepareFirstFactor({ strategy: 'email_code' })` | `signIn.emailCode.sendCode()` |
+| `signIn.attemptFirstFactor({ strategy: 'email_code', code })` | `signIn.emailCode.verifyCode({ code })` |
+| `signIn.prepareFirstFactor({ strategy: 'phone_code' })` | `signIn.phoneCode.sendCode()` |
+| `signIn.attemptFirstFactor({ strategy: 'phone_code', code })` | `signIn.phoneCode.verifyCode({ code })` |
+| `signIn.prepareSecondFactor({ strategy: 'email_code' })` | `signIn.mfa.sendEmailCode()` |
+| `signIn.attemptSecondFactor({ strategy: 'email_code', code })` | `signIn.mfa.verifyEmailCode({ code })` |
+| `signIn.attemptSecondFactor({ strategy: 'phone_code', code })` | `signIn.mfa.verifyPhoneCode({ code })` |
+| `signIn.attemptSecondFactor({ strategy: 'totp', code })` | `signIn.mfa.verifyTOTP({ code })` |
+| `signIn.attemptSecondFactor({ strategy: 'backup_code', code })` | `signIn.mfa.verifyBackupCode({ code })` |
+| `signIn.prepareFirstFactor({ strategy: 'reset_password_email_code' })` | `signIn.resetPasswordEmailCode.sendCode()` |
+| `signIn.attemptFirstFactor({ strategy: 'reset_password_email_code', code })` | `signIn.resetPasswordEmailCode.verifyCode({ code })` |
+| `signIn.resetPassword({ password })` | `signIn.resetPasswordEmailCode.submitPassword({ password })` |
+| `setActive({ session: signIn.createdSessionId })` | `signIn.finalize({ navigate })` |
+| try/catch with `isClerkAPIResponseError()` | `errors.fields`, `errors.global`, `errors.raw` |
+
+## Hook API
+
+```typescript
+import { useSignIn } from '@clerk/nextjs' // or @clerk/react, @clerk/expo
+
+const { signIn, errors, fetchStatus } = useSignIn()
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `signIn` | `SignInFuture` | Sign-in object with namespaced methods |
+| `errors` | `Errors<SignInFields>` | Structured error object |
+| `fetchStatus` | `'idle' \| 'fetching'` | Network request status |
+
+## Sign-In Methods
+
+### Password
+
+```typescript
+const { error } = await signIn.password({
+  identifier: 'user@example.com',
+  password: 'securePassword123',
+})
+```
+
+### SSO (OAuth / Enterprise)
+
+```typescript
+const { error } = await signIn.sso({
+  strategy: 'oauth_google', // or 'oauth_github', 'enterprise_sso', etc.
+})
+```
+
+### Passkey
+
+```typescript
+const { error } = await signIn.passkey({ flow: 'discoverable' })
+```
+
+### Web3
+
+```typescript
+const { error } = await signIn.web3({ strategy: 'web3_solana_signature' })
+// or
+const { error } = await signIn.web3({ strategy: 'web3_base_signature' })
+```
+
+### Ticket (Invitation link)
+
+```typescript
+const { error } = await signIn.ticket({ ticket: 'ticket_abc123' })
+```
+
+### Email Code
+
+```typescript
+// Send code
+const { error } = await signIn.emailCode.sendCode()
+
+// Verify code
+const { error } = await signIn.emailCode.verifyCode({ code: '123456' })
+```
+
+### Phone Code
+
+```typescript
+// Send code
+const { error } = await signIn.phoneCode.sendCode()
+
+// Verify code
+const { error } = await signIn.phoneCode.verifyCode({ code: '123456' })
+```
+
+## MFA (Second Factor)
+
+When the sign-in requires a second factor:
+
+```typescript
+// TOTP (Authenticator app)
+const { error } = await signIn.mfa.verifyTOTP({ code: '123456' })
+
+// Backup code
+const { error } = await signIn.mfa.verifyBackupCode({ code: 'backup-code-here' })
+
+// Email code
+const { error: sendErr } = await signIn.mfa.sendEmailCode()
+const { error: verifyErr } = await signIn.mfa.verifyEmailCode({ code: '123456' })
+
+// Phone code
+const { error: sendErr } = await signIn.mfa.sendPhoneCode()
+const { error: verifyErr } = await signIn.mfa.verifyPhoneCode({ code: '123456' })
+```
+
+## Password Reset
+
+```typescript
+// 1. Send reset code
+const { error } = await signIn.resetPasswordEmailCode.sendCode()
+
+// 2. Verify the code
+const { error } = await signIn.resetPasswordEmailCode.verifyCode({ code: '123456' })
+
+// 3. Submit new password
+const { error } = await signIn.resetPasswordEmailCode.submitPassword({
+  password: 'newSecurePassword123',
+})
+```
+
+## Client Trust
+
+When a user signs in with a valid password from a new device without MFA enabled, the sign-in status becomes `needs_client_trust`. This requires an additional verification step:
+
+```typescript
+if (signIn.status === 'needs_client_trust') {
+  // Check supportedSecondFactors for available methods (email_code or phone_code)
+  const factors = signIn.supportedSecondFactors
+  // Use the appropriate mfa method to verify
+}
+```
+
+## Finalizing Sign-In
+
+After successful authentication, call `finalize()` to activate the session:
+
+```typescript
+await signIn.finalize({
+  navigate: async ({ session, decorateUrl }) => {
+    // Check for session tasks (e.g., forced password reset, MFA setup)
+    if (session?.currentTask) {
+      const taskUrl = decorateUrl(`/sign-in/tasks/${session.currentTask}`)
+      router.push(taskUrl)
+      return
+    }
+    const url = decorateUrl('/')
+    router.push(url)
+  },
+})
+```
+
+- `decorateUrl(path)` — decorates the URL with session info (required)
+- `session?.currentTask` — check for pending session tasks before redirecting
+
+### Reset State
+
+Clear local sign-in state and start over:
+
+```typescript
+signIn.reset()
+```
+
+## Error Handling
+
+All methods return `Promise<{ error: ClerkError | null }>`. Errors are also available reactively on the hook:
+
+```typescript
+const { signIn, errors } = useSignIn()
+
+// Field-level errors
+errors?.fields?.identifier // { code, message, longMessage? }
+errors?.fields?.password   // { code, message, longMessage? }
+errors?.fields?.code       // { code, message, longMessage? }
+
+// Global errors (not tied to a field)
+errors?.global // ClerkGlobalHookError[] | null
+
+// Raw error array
+errors?.raw // ClerkError[] | null
+```
+
+## Complete Example: Email/Password with MFA
+
+```tsx
+'use client'
+import { useState } from 'react'
+import { useSignIn } from '@clerk/nextjs'
+import { useRouter } from 'next/navigation'
+
+export default function SignInPage() {
+  const { signIn, errors, fetchStatus } = useSignIn()
+  const router = useRouter()
+
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+  const [mfaCode, setMfaCode] = useState('')
+  const [step, setStep] = useState<'credentials' | 'mfa'>('credentials')
+
+  async function handleSignIn(e: React.FormEvent) {
+    e.preventDefault()
+    const { error } = await signIn.password({ identifier, password })
+
+    if (error) return // errors are available via `errors` object
+
+    if (signIn.status === 'needs_second_factor' || signIn.status === 'needs_client_trust') {
+      setStep('mfa')
+      return
+    }
+
+    await signIn.finalize({
+      navigate: async ({ session, decorateUrl }) => {
+        if (session?.currentTask) {
+          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask}`))
+          return
+        }
+        router.push(decorateUrl('/'))
+      },
+    })
+  }
+
+  async function handleMFA(e: React.FormEvent) {
+    e.preventDefault()
+    const { error } = await signIn.mfa.verifyTOTP({ code: mfaCode })
+    if (error) return
+
+    await signIn.finalize({
+      navigate: async ({ session, decorateUrl }) => {
+        if (session?.currentTask) {
+          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask}`))
+          return
+        }
+        router.push(decorateUrl('/'))
+      },
+    })
+  }
+
+  if (step === 'mfa') {
+    return (
+      <form onSubmit={handleMFA}>
+        <input
+          type="text"
+          value={mfaCode}
+          onChange={(e) => setMfaCode(e.target.value)}
+          placeholder="Enter MFA code"
+        />
+        {errors?.fields?.code && <p>{errors.fields.code.message}</p>}
+        <button type="submit" disabled={fetchStatus === 'fetching'}>
+          Verify
+        </button>
+      </form>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSignIn}>
+      <input
+        type="email"
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
+        placeholder="Email"
+      />
+      {errors?.fields?.identifier && <p>{errors.fields.identifier.message}</p>}
+
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      {errors?.fields?.password && <p>{errors.fields.password.message}</p>}
+
+      {errors?.global?.map((err, i) => <p key={i}>{err.message}</p>)}
+
+      <button type="submit" disabled={fetchStatus === 'fetching'}>
+        Sign In
+      </button>
+    </form>
+  )
+}
+```
+
+## Docs
+
+- [Custom sign-in flow](https://clerk.com/docs/custom-flows/overview)
+- [useSignIn() reference](https://clerk.com/docs/references/react/use-sign-in)

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -179,108 +179,130 @@ errors?.raw // ClerkError[] | null
 
 ## Complete Example: Email/Password with MFA
 
+From [the docs](https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication). Supports SMS verification codes, authenticator app (TOTP), and backup codes.
+
 ```tsx
 'use client'
-import { useState } from 'react'
+
 import { useSignIn } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
 
-export default function SignInPage() {
+export default function Page() {
   const { signIn, errors, fetchStatus } = useSignIn()
   const router = useRouter()
 
-  const [identifier, setIdentifier] = useState('')
-  const [password, setPassword] = useState('')
-  const [mfaCode, setMfaCode] = useState('')
-  const [step, setStep] = useState<'credentials' | 'mfa'>('credentials')
+  const handleSubmit = async (formData: FormData) => {
+    const emailAddress = formData.get('email') as string
+    const password = formData.get('password') as string
 
-  async function handleSignIn(e: React.FormEvent) {
-    e.preventDefault()
-    const { error } = await signIn.password({ identifier, password })
+    await signIn.password({
+      emailAddress,
+      password,
+    })
 
-    if (error) return // errors are available via `errors` object
-
-    if (signIn.status === 'needs_second_factor' || signIn.status === 'needs_client_trust') {
-      setStep('mfa')
-      return
+    // If you're using the authenticator app strategy, remove this check.
+    if (signIn.status === 'needs_second_factor') {
+      await signIn.mfa.sendPhoneCode()
     }
 
-    await signIn.finalize({
-      navigate: async ({ session, decorateUrl }) => {
-        const dest = session.currentTask
-          ? `/sign-in/tasks/${session.currentTask.key}`
-          : '/'
-        const url = decorateUrl(dest)
-        if (url.startsWith('http')) {
-          window.location.href = url
-        } else {
-          router.push(url)
-        }
-      },
-    })
+    if (signIn.status === 'complete') {
+      await signIn.finalize({
+        navigate: ({ session, decorateUrl }) => {
+          if (session?.currentTask) {
+            // Handle pending session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            console.log(session?.currentTask)
+            return
+          }
+
+          const url = decorateUrl('/')
+          if (url.startsWith('http')) {
+            window.location.href = url
+          } else {
+            router.push(url)
+          }
+        },
+      })
+    }
   }
 
-  async function handleMFA(e: React.FormEvent) {
-    e.preventDefault()
-    const { error } = await signIn.mfa.verifyTOTP({ code: mfaCode })
-    if (error) return
+  const handleMFAVerification = async (formData: FormData) => {
+    const code = formData.get('code') as string
+    const useBackupCode = formData.get('useBackupCode') === 'on'
 
-    await signIn.finalize({
-      navigate: async ({ session, decorateUrl }) => {
-        const dest = session.currentTask
-          ? `/sign-in/tasks/${session.currentTask.key}`
-          : '/'
-        const url = decorateUrl(dest)
-        if (url.startsWith('http')) {
-          window.location.href = url
-        } else {
-          router.push(url)
-        }
-      },
-    })
+    if (useBackupCode) {
+      await signIn.mfa.verifyBackupCode({ code })
+    } else {
+      await signIn.mfa.verifyPhoneCode({ code })
+      // If you're using the authenticator app strategy, use the following method instead:
+      // await signIn.mfa.verifyTOTP({ code })
+    }
+
+    if (signIn.status === 'complete') {
+      await signIn.finalize({
+        navigate: ({ session, decorateUrl }) => {
+          if (session?.currentTask) {
+            // Handle pending session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            console.log(session?.currentTask)
+            return
+          }
+
+          const url = decorateUrl('/')
+          if (url.startsWith('http')) {
+            window.location.href = url
+          } else {
+            router.push(url)
+          }
+        },
+      })
+    }
   }
 
-  if (step === 'mfa') {
+  if (signIn.status === 'needs_second_factor') {
     return (
-      <form onSubmit={handleMFA}>
-        <input
-          type="text"
-          value={mfaCode}
-          onChange={(e) => setMfaCode(e.target.value)}
-          placeholder="Enter MFA code"
-        />
-        {errors?.fields?.code && <p>{errors.fields.code.message}</p>}
-        <button type="submit" disabled={fetchStatus === 'fetching'}>
-          Verify
-        </button>
-      </form>
+      <div>
+        <h1>Verify your account</h1>
+        <form action={handleMFAVerification}>
+          <div>
+            <label htmlFor="code">Code</label>
+            <input id="code" name="code" type="text" />
+            {errors.fields.code && <p>{errors.fields.code.message}</p>}
+          </div>
+          <div>
+            <label>
+              Use backup code
+              <input type="checkbox" name="useBackupCode" />
+            </label>
+          </div>
+          <button type="submit" disabled={fetchStatus === 'fetching'}>
+            Verify
+          </button>
+        </form>
+      </div>
     )
   }
 
   return (
-    <form onSubmit={handleSignIn}>
-      <input
-        type="email"
-        value={identifier}
-        onChange={(e) => setIdentifier(e.target.value)}
-        placeholder="Email"
-      />
-      {errors?.fields?.identifier && <p>{errors.fields.identifier.message}</p>}
-
-      <input
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="Password"
-      />
-      {errors?.fields?.password && <p>{errors.fields.password.message}</p>}
-
-      {errors?.global?.map((err, i) => <p key={i}>{err.message}</p>)}
-
-      <button type="submit" disabled={fetchStatus === 'fetching'}>
-        Sign In
-      </button>
-    </form>
+    <>
+      <h1>Sign in</h1>
+      <form action={handleSubmit}>
+        <div>
+          <label htmlFor="email">Enter email address</label>
+          <input id="email" name="email" type="email" />
+          {errors.fields.identifier && <p>{errors.fields.identifier.message}</p>}
+        </div>
+        <div>
+          <label htmlFor="password">Enter password</label>
+          <input id="password" name="password" type="password" />
+          {errors.fields.password && <p>{errors.fields.password.message}</p>}
+        </div>
+        <button type="submit" disabled={fetchStatus === 'fetching'}>
+          Continue
+        </button>
+      </form>
+      {errors && <p>{JSON.stringify(errors, null, 2)}</p>}
+    </>
   )
 }
 ```
@@ -288,4 +310,5 @@ export default function SignInPage() {
 ## Docs
 
 - [Custom sign-in flow](https://clerk.com/docs/custom-flows/overview)
+- [MFA custom flow](https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication)
 - [useSignIn() reference](https://clerk.com/docs/references/react/use-sign-in)

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -131,14 +131,16 @@ After successful authentication, call `finalize()` to activate the session:
 ```typescript
 await signIn.finalize({
   navigate: async ({ session, decorateUrl }) => {
-    // Check for session tasks (e.g., forced password reset, MFA setup)
-    if (session.currentTask) {
-      const taskUrl = decorateUrl(`/sign-in/tasks/${session.currentTask.key}`)
-      router.push(taskUrl)
-      return
+    const destination = session.currentTask
+      ? `/sign-in/tasks/${session.currentTask.key}`
+      : '/'
+    const url = decorateUrl(destination)
+    // decorateUrl may return an absolute URL for Safari ITP
+    if (url.startsWith('http')) {
+      window.location.href = url
+    } else {
+      router.push(url)
     }
-    const url = decorateUrl('/')
-    router.push(url)
   },
 })
 ```
@@ -203,11 +205,15 @@ export default function SignInPage() {
 
     await signIn.finalize({
       navigate: async ({ session, decorateUrl }) => {
-        if (session.currentTask) {
-          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask.key}`))
-          return
+        const dest = session.currentTask
+          ? `/sign-in/tasks/${session.currentTask.key}`
+          : '/'
+        const url = decorateUrl(dest)
+        if (url.startsWith('http')) {
+          window.location.href = url
+        } else {
+          router.push(url)
         }
-        router.push(decorateUrl('/'))
       },
     })
   }
@@ -219,11 +225,15 @@ export default function SignInPage() {
 
     await signIn.finalize({
       navigate: async ({ session, decorateUrl }) => {
-        if (session.currentTask) {
-          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask.key}`))
-          return
+        const dest = session.currentTask
+          ? `/sign-in/tasks/${session.currentTask.key}`
+          : '/'
+        const url = decorateUrl(dest)
+        if (url.startsWith('http')) {
+          window.location.href = url
+        } else {
+          router.push(url)
         }
-        router.push(decorateUrl('/'))
       },
     })
   }

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -132,8 +132,8 @@ After successful authentication, call `finalize()` to activate the session:
 await signIn.finalize({
   navigate: async ({ session, decorateUrl }) => {
     // Check for session tasks (e.g., forced password reset, MFA setup)
-    if (session?.currentTask) {
-      const taskUrl = decorateUrl(`/sign-in/tasks/${session.currentTask}`)
+    if (session.currentTask) {
+      const taskUrl = decorateUrl(`/sign-in/tasks/${session.currentTask.key}`)
       router.push(taskUrl)
       return
     }
@@ -203,8 +203,8 @@ export default function SignInPage() {
 
     await signIn.finalize({
       navigate: async ({ session, decorateUrl }) => {
-        if (session?.currentTask) {
-          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask}`))
+        if (session.currentTask) {
+          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask.key}`))
           return
         }
         router.push(decorateUrl('/'))
@@ -219,8 +219,8 @@ export default function SignInPage() {
 
     await signIn.finalize({
       navigate: async ({ session, decorateUrl }) => {
-        if (session?.currentTask) {
-          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask}`))
+        if (session.currentTask) {
+          router.push(decorateUrl(`/sign-in/tasks/${session.currentTask.key}`))
           return
         }
         router.push(decorateUrl('/'))

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -32,6 +32,8 @@ const { error } = await signIn.password({
 ```typescript
 const { error } = await signIn.sso({
   strategy: 'oauth_google', // or 'oauth_github', 'enterprise_sso', etc.
+  redirectUrl: '/dashboard', // where to go after SSO completes
+  redirectCallbackUrl: '/sso-callback', // intermediate callback route
 })
 ```
 

--- a/skills/custom-ui/core-3/custom-sign-in.md
+++ b/skills/custom-ui/core-3/custom-sign-in.md
@@ -58,8 +58,8 @@ const { error } = await signIn.ticket({ ticket: 'ticket_abc123' })
 ### Email Code
 
 ```typescript
-// Send code
-const { error } = await signIn.emailCode.sendCode()
+// Send code (emailAddress is optional if a signIn already exists from a prior method call)
+const { error } = await signIn.emailCode.sendCode({ emailAddress: 'user@example.com' })
 
 // Verify code
 const { error } = await signIn.emailCode.verifyCode({ code: '123456' })
@@ -68,8 +68,8 @@ const { error } = await signIn.emailCode.verifyCode({ code: '123456' })
 ### Phone Code
 
 ```typescript
-// Send code
-const { error } = await signIn.phoneCode.sendCode()
+// Send code (phoneNumber is optional if a signIn already exists from a prior method call)
+const { error } = await signIn.phoneCode.sendCode({ phoneNumber: '+12015551234' })
 
 // Verify code
 const { error } = await signIn.phoneCode.verifyCode({ code: '123456' })

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -83,7 +83,8 @@ const { error } = await signUp.verifications.verifyPhoneCode({ code: '123456' })
 ### Email Link
 
 ```typescript
-const { error } = await signUp.verifications.sendEmailLink()
+// verificationUrl: where the user lands after clicking the email link (relative or absolute)
+const { error } = await signUp.verifications.sendEmailLink({ verificationUrl: '/verify' })
 // User clicks the link in their email to verify
 ```
 

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -111,15 +111,7 @@ await signUp.finalize({
 
 ### Transferable Sign-Ups
 
-If `signUp.isTransferable` is `true`, the identifier matches an existing user — transfer to sign-in instead:
-
-```typescript
-if (signUp.isTransferable) {
-  // Redirect to sign-in page
-  router.push('/sign-in')
-  return
-}
-```
+If `signUp.isTransferable` is `true`, the identifier matches an existing user and the sign-up should be transferred to a sign-in flow. This involves coordinating between sign-up and sign-in resources. See the [transferable sign-up docs](https://clerk.com/docs/custom-flows/overview) for the full implementation.
 
 ### Reset State
 

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -90,8 +90,8 @@ After successful sign-up and verification, call `finalize()` to activate the ses
 ```typescript
 await signUp.finalize({
   navigate: async ({ session, decorateUrl }) => {
-    if (session?.currentTask) {
-      const taskUrl = decorateUrl(`/sign-up/tasks/${session.currentTask}`)
+    if (session.currentTask) {
+      const taskUrl = decorateUrl(`/sign-up/tasks/${session.currentTask.key}`)
       router.push(taskUrl)
       return
     }
@@ -183,8 +183,8 @@ export default function SignUpPage() {
 
     await signUp.finalize({
       navigate: async ({ session, decorateUrl }) => {
-        if (session?.currentTask) {
-          router.push(decorateUrl(`/sign-up/tasks/${session.currentTask}`))
+        if (session.currentTask) {
+          router.push(decorateUrl(`/sign-up/tasks/${session.currentTask.key}`))
           return
         }
         router.push(decorateUrl('/'))

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -68,17 +68,6 @@ const { error } = await signUp.update({
 })
 ```
 
-### Upsert (create or update)
-
-Conditionally creates a new sign-up or updates the existing one:
-
-```typescript
-const { error } = await signUp.upsert({
-  emailAddress: 'user@example.com',
-  password: 'securePassword123',
-})
-```
-
 ## Email / Phone Verification
 
 After creating a sign-up, verify the user's email or phone:

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -34,6 +34,8 @@ const { error } = await signUp.password({
 ```typescript
 const { error } = await signUp.sso({
   strategy: 'oauth_google', // or 'oauth_github', etc.
+  redirectUrl: '/dashboard', // where to go after SSO completes
+  redirectCallbackUrl: '/sso-callback', // intermediate callback route
 })
 ```
 

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -2,22 +2,6 @@
 
 Build a custom sign-up experience using the `useSignUp()` hook.
 
-> **Core 2:** The `useSignUp()` hook returns a completely different shape in Core 2. If the project uses `@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, or `@clerk/clerk-expo` v1–v2, see `core-2/custom-sign-up.md` instead. Key differences: returns `{ signUp, isLoaded, setActive }`, uses `create()` / `prepareVerification()` / `attemptVerification()` methods, and `setActive({ session: signUp.createdSessionId })` to finalize. Errors use try/catch with `isClerkAPIResponseError()`.
-
-## Quick Reference: Core 2 → Current
-
-| Core 2 | Current |
-|--------|---------|
-| `signUp.create({ emailAddress, password })` | `signUp.password({ emailAddress, password })` |
-| `signUp.authenticateWithRedirect()` | `signUp.sso()` |
-| `signUp.prepareVerification({ strategy: 'email_code' })` | `signUp.verifications.sendEmailCode()` |
-| `signUp.attemptVerification({ strategy: 'email_code', code })` | `signUp.verifications.verifyEmailCode({ code })` |
-| `signUp.prepareVerification({ strategy: 'phone_code' })` | `signUp.verifications.sendPhoneCode()` |
-| `signUp.attemptVerification({ strategy: 'phone_code', code })` | `signUp.verifications.verifyPhoneCode({ code })` |
-| `signUp.prepareVerification({ strategy: 'email_link' })` | `signUp.verifications.sendEmailLink()` |
-| `setActive({ session: signUp.createdSessionId })` | `signUp.finalize({ navigate })` |
-| try/catch with `isClerkAPIResponseError()` | `errors.fields`, `errors.global`, `errors.raw` |
-
 ## Hook API
 
 ```typescript

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -45,10 +45,14 @@ const { error } = await signUp.web3({ strategy: 'web3_solana_signature' })
 
 ### Update (add fields to existing sign-up)
 
+Use `update()` to add optional fields (name, metadata, legal acceptance, locale) to an existing sign-up before finalization.
+
 ```typescript
 const { error } = await signUp.update({
   firstName: 'Jane',
   lastName: 'Doe',
+  unsafeMetadata: { referralSource: 'twitter' },
+  legalAccepted: true,
 })
 ```
 

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -90,13 +90,16 @@ After successful sign-up and verification, call `finalize()` to activate the ses
 ```typescript
 await signUp.finalize({
   navigate: async ({ session, decorateUrl }) => {
-    if (session.currentTask) {
-      const taskUrl = decorateUrl(`/sign-up/tasks/${session.currentTask.key}`)
-      router.push(taskUrl)
-      return
+    const destination = session.currentTask
+      ? `/sign-up/tasks/${session.currentTask.key}`
+      : '/'
+    const url = decorateUrl(destination)
+    // decorateUrl may return an absolute URL for Safari ITP
+    if (url.startsWith('http')) {
+      window.location.href = url
+    } else {
+      router.push(url)
     }
-    const url = decorateUrl('/')
-    router.push(url)
   },
 })
 ```
@@ -183,11 +186,15 @@ export default function SignUpPage() {
 
     await signUp.finalize({
       navigate: async ({ session, decorateUrl }) => {
-        if (session.currentTask) {
-          router.push(decorateUrl(`/sign-up/tasks/${session.currentTask.key}`))
-          return
+        const dest = session.currentTask
+          ? `/sign-up/tasks/${session.currentTask.key}`
+          : '/'
+        const url = decorateUrl(dest)
+        if (url.startsWith('http')) {
+          window.location.href = url
+        } else {
+          router.push(url)
         }
-        router.push(decorateUrl('/'))
       },
     })
   }

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -1,0 +1,271 @@
+# Custom Sign-Up Flow
+
+Build a custom sign-up experience using the `useSignUp()` hook.
+
+> **Core 2:** The `useSignUp()` hook returns a completely different shape in Core 2. If the project uses `@clerk/nextjs` v5–v6, `@clerk/clerk-react` v5–v6, or `@clerk/clerk-expo` v1–v2, see `core-2/custom-sign-up.md` instead. Key differences: returns `{ signUp, isLoaded, setActive }`, uses `create()` / `prepareVerification()` / `attemptVerification()` methods, and `setActive({ session: signUp.createdSessionId })` to finalize. Errors use try/catch with `isClerkAPIResponseError()`.
+
+## Quick Reference: Core 2 → Current
+
+| Core 2 | Current |
+|--------|---------|
+| `signUp.create({ emailAddress, password })` | `signUp.password({ emailAddress, password })` |
+| `signUp.authenticateWithRedirect()` | `signUp.sso()` |
+| `signUp.prepareVerification({ strategy: 'email_code' })` | `signUp.verifications.sendEmailCode()` |
+| `signUp.attemptVerification({ strategy: 'email_code', code })` | `signUp.verifications.verifyEmailCode({ code })` |
+| `signUp.prepareVerification({ strategy: 'phone_code' })` | `signUp.verifications.sendPhoneCode()` |
+| `signUp.attemptVerification({ strategy: 'phone_code', code })` | `signUp.verifications.verifyPhoneCode({ code })` |
+| `signUp.prepareVerification({ strategy: 'email_link' })` | `signUp.verifications.sendEmailLink()` |
+| `setActive({ session: signUp.createdSessionId })` | `signUp.finalize({ navigate })` |
+| try/catch with `isClerkAPIResponseError()` | `errors.fields`, `errors.global`, `errors.raw` |
+
+## Hook API
+
+```typescript
+import { useSignUp } from '@clerk/nextjs' // or @clerk/react, @clerk/expo
+
+const { signUp, errors, fetchStatus } = useSignUp()
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `signUp` | `SignUpFuture` | Sign-up object with namespaced methods |
+| `errors` | `Errors<SignUpFields>` | Structured error object |
+| `fetchStatus` | `'idle' \| 'fetching'` | Network request status |
+
+## Sign-Up Methods
+
+### Password (Email/Password)
+
+```typescript
+const { error } = await signUp.password({
+  emailAddress: 'user@example.com',
+  password: 'securePassword123',
+  firstName: 'Jane',  // optional
+  lastName: 'Doe',    // optional
+})
+```
+
+### SSO (OAuth)
+
+```typescript
+const { error } = await signUp.sso({
+  strategy: 'oauth_google', // or 'oauth_github', etc.
+})
+```
+
+### Web3
+
+```typescript
+const { error } = await signUp.web3({ strategy: 'web3_solana_signature' })
+```
+
+### Update (add fields to existing sign-up)
+
+```typescript
+const { error } = await signUp.update({
+  firstName: 'Jane',
+  lastName: 'Doe',
+})
+```
+
+### Upsert (create or update)
+
+Conditionally creates a new sign-up or updates the existing one:
+
+```typescript
+const { error } = await signUp.upsert({
+  emailAddress: 'user@example.com',
+  password: 'securePassword123',
+})
+```
+
+## Email / Phone Verification
+
+After creating a sign-up, verify the user's email or phone:
+
+### Email Code
+
+```typescript
+// Send verification code
+const { error } = await signUp.verifications.sendEmailCode()
+
+// Verify the code
+const { error } = await signUp.verifications.verifyEmailCode({ code: '123456' })
+```
+
+### Phone Code
+
+```typescript
+// Send verification code
+const { error } = await signUp.verifications.sendPhoneCode()
+
+// Verify the code
+const { error } = await signUp.verifications.verifyPhoneCode({ code: '123456' })
+```
+
+### Email Link
+
+```typescript
+const { error } = await signUp.verifications.sendEmailLink()
+// User clicks the link in their email to verify
+```
+
+## Finalizing Sign-Up
+
+After successful sign-up and verification, call `finalize()` to activate the session:
+
+```typescript
+await signUp.finalize({
+  navigate: async ({ session, decorateUrl }) => {
+    if (session?.currentTask) {
+      const taskUrl = decorateUrl(`/sign-up/tasks/${session.currentTask}`)
+      router.push(taskUrl)
+      return
+    }
+    const url = decorateUrl('/')
+    router.push(url)
+  },
+})
+```
+
+### Transferable Sign-Ups
+
+If `signUp.isTransferable` is `true`, the identifier matches an existing user — transfer to sign-in instead:
+
+```typescript
+if (signUp.isTransferable) {
+  // Redirect to sign-in page
+  router.push('/sign-in')
+  return
+}
+```
+
+### Reset State
+
+Clear local sign-up state and start over:
+
+```typescript
+signUp.reset()
+```
+
+## Error Handling
+
+All methods return `Promise<{ error: ClerkError | null }>`. Errors are also available reactively on the hook:
+
+```typescript
+const { signUp, errors } = useSignUp()
+
+// Field-level errors
+errors?.fields?.emailAddress // { code, message, longMessage? }
+errors?.fields?.password     // { code, message, longMessage? }
+errors?.fields?.firstName    // { code, message, longMessage? }
+errors?.fields?.lastName     // { code, message, longMessage? }
+errors?.fields?.phoneNumber  // { code, message, longMessage? }
+errors?.fields?.username     // { code, message, longMessage? }
+errors?.fields?.code         // { code, message, longMessage? }
+
+// Global errors
+errors?.global // ClerkGlobalHookError[] | null
+
+// Raw error array
+errors?.raw // ClerkError[] | null
+```
+
+## Complete Example: Email/Password with Email Verification
+
+```tsx
+'use client'
+import { useState } from 'react'
+import { useSignUp } from '@clerk/nextjs'
+import { useRouter } from 'next/navigation'
+
+export default function SignUpPage() {
+  const { signUp, errors, fetchStatus } = useSignUp()
+  const router = useRouter()
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [code, setCode] = useState('')
+  const [step, setStep] = useState<'register' | 'verify'>('register')
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault()
+    const { error } = await signUp.password({
+      emailAddress: email,
+      password,
+    })
+    if (error) return
+
+    // Send email verification code
+    const { error: sendError } = await signUp.verifications.sendEmailCode()
+    if (sendError) return
+
+    setStep('verify')
+  }
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault()
+    const { error } = await signUp.verifications.verifyEmailCode({ code })
+    if (error) return
+
+    await signUp.finalize({
+      navigate: async ({ session, decorateUrl }) => {
+        if (session?.currentTask) {
+          router.push(decorateUrl(`/sign-up/tasks/${session.currentTask}`))
+          return
+        }
+        router.push(decorateUrl('/'))
+      },
+    })
+  }
+
+  if (step === 'verify') {
+    return (
+      <form onSubmit={handleVerify}>
+        <p>Check your email for a verification code.</p>
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="Verification code"
+        />
+        {errors?.fields?.code && <p>{errors.fields.code.message}</p>}
+        <button type="submit" disabled={fetchStatus === 'fetching'}>
+          Verify Email
+        </button>
+      </form>
+    )
+  }
+
+  return (
+    <form onSubmit={handleRegister}>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      {errors?.fields?.emailAddress && <p>{errors.fields.emailAddress.message}</p>}
+
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      {errors?.fields?.password && <p>{errors.fields.password.message}</p>}
+
+      {errors?.global?.map((err, i) => <p key={i}>{err.message}</p>)}
+
+      <button type="submit" disabled={fetchStatus === 'fetching'}>
+        Sign Up
+      </button>
+    </form>
+  )
+}
+```
+
+## Docs
+
+- [Custom sign-up flow](https://clerk.com/docs/custom-flows/overview)
+- [useSignUp() reference](https://clerk.com/docs/references/react/use-sign-up)

--- a/skills/custom-ui/core-3/custom-sign-up.md
+++ b/skills/custom-ui/core-3/custom-sign-up.md
@@ -146,100 +146,108 @@ errors?.global // ClerkGlobalHookError[] | null
 errors?.raw // ClerkError[] | null
 ```
 
-## Complete Example: Email/Password with Email Verification
+## Complete Example: Phone OTP Sign-Up
+
+From [the docs](https://clerk.com/docs/guides/development/custom-flows/authentication/email-sms-otp). Uses phone OTP with inline comments for adapting to email OTP.
 
 ```tsx
 'use client'
-import { useState } from 'react'
-import { useSignUp } from '@clerk/nextjs'
+
+import * as React from 'react'
+import { useAuth, useSignUp } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
 
 export default function SignUpPage() {
   const { signUp, errors, fetchStatus } = useSignUp()
+  const { isSignedIn } = useAuth()
   const router = useRouter()
 
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [code, setCode] = useState('')
-  const [step, setStep] = useState<'register' | 'verify'>('register')
+  const handleSubmit = async (formData: FormData) => {
+    // For email OTP: collect the email address instead of the phone number
+    const phoneNumber = formData.get('phoneNumber') as string
 
-  async function handleRegister(e: React.FormEvent) {
-    e.preventDefault()
-    const { error } = await signUp.password({
-      emailAddress: email,
-      password,
-    })
-    if (error) return
+    // For email OTP: change create({ phoneNumber }) to create({ emailAddress })
+    const error = await signUp.create({ phoneNumber })
 
-    // Send email verification code
-    const { error: sendError } = await signUp.verifications.sendEmailCode()
-    if (sendError) return
-
-    setStep('verify')
+    // For email OTP: change sendPhoneCode() to sendEmailCode()
+    if (!error) await signUp.verifications.sendPhoneCode()
   }
 
-  async function handleVerify(e: React.FormEvent) {
-    e.preventDefault()
-    const { error } = await signUp.verifications.verifyEmailCode({ code })
-    if (error) return
+  const handleVerify = async (formData: FormData) => {
+    const code = formData.get('code') as string
 
-    await signUp.finalize({
-      navigate: async ({ session, decorateUrl }) => {
-        const dest = session.currentTask
-          ? `/sign-up/tasks/${session.currentTask.key}`
-          : '/'
-        const url = decorateUrl(dest)
-        if (url.startsWith('http')) {
-          window.location.href = url
-        } else {
-          router.push(url)
-        }
-      },
-    })
+    // For email OTP: change verifyPhoneCode() to verifyEmailCode()
+    await signUp.verifications.verifyPhoneCode({ code })
+
+    if (signUp.status === 'complete') {
+      await signUp.finalize({
+        navigate: ({ session, decorateUrl }) => {
+          if (session?.currentTask) {
+            // Handle pending session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            console.log(session?.currentTask)
+            return
+          }
+
+          const url = decorateUrl('/')
+          if (url.startsWith('http')) {
+            window.location.href = url
+          } else {
+            router.push(url)
+          }
+        },
+      })
+    }
   }
 
-  if (step === 'verify') {
+  if (signUp.status === 'complete' || isSignedIn) {
+    return null
+  }
+
+  if (
+    signUp.status === 'missing_requirements' &&
+    // For email OTP: check for phone_number instead of email_address
+    signUp.unverifiedFields.includes('phone_number') &&
+    signUp.missingFields.length === 0
+  ) {
     return (
-      <form onSubmit={handleVerify}>
-        <p>Check your email for a verification code.</p>
-        <input
-          type="text"
-          value={code}
-          onChange={(e) => setCode(e.target.value)}
-          placeholder="Verification code"
-        />
-        {errors?.fields?.code && <p>{errors.fields.code.message}</p>}
-        <button type="submit" disabled={fetchStatus === 'fetching'}>
-          Verify Email
-        </button>
-      </form>
+      <>
+        <h1>Verify your account</h1>
+        <form action={handleVerify}>
+          <div>
+            <label htmlFor="code">Code</label>
+            <input id="code" name="code" type="text" />
+          </div>
+          {errors.fields.code && <p>{errors.fields.code.message}</p>}
+          <button type="submit" disabled={fetchStatus === 'fetching'}>
+            Verify
+          </button>
+        </form>
+        {/* For email OTP: change sendPhoneCode() to sendEmailCode() */}
+        <button onClick={() => signUp.verifications.sendPhoneCode()}>I need a new code</button>
+      </>
     )
   }
 
   return (
-    <form onSubmit={handleRegister}>
-      <input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="Email"
-      />
-      {errors?.fields?.emailAddress && <p>{errors.fields.emailAddress.message}</p>}
+    <>
+      <h1>Sign up</h1>
+      <form action={handleSubmit}>
+        {/* For email OTP: collect the emailAddress instead */}
+        <div>
+          <label htmlFor="phoneNumber">Phone number</label>
+          <input id="phoneNumber" name="phoneNumber" type="tel" />
+          {errors.fields.phoneNumber && <p>{errors.fields.phoneNumber.message}</p>}
+        </div>
+        <button type="submit" disabled={fetchStatus === 'fetching'}>
+          Continue
+        </button>
+      </form>
+      {errors && <p>{JSON.stringify(errors, null, 2)}</p>}
 
-      <input
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="Password"
-      />
-      {errors?.fields?.password && <p>{errors.fields.password.message}</p>}
-
-      {errors?.global?.map((err, i) => <p key={i}>{err.message}</p>)}
-
-      <button type="submit" disabled={fetchStatus === 'fetching'}>
-        Sign Up
-      </button>
-    </form>
+      {/* Required for sign-up flows. Clerk's bot sign-up protection is enabled by default */}
+      <div id="clerk-captcha" />
+    </>
   )
 }
 ```
@@ -247,4 +255,5 @@ export default function SignUpPage() {
 ## Docs
 
 - [Custom sign-up flow](https://clerk.com/docs/custom-flows/overview)
+- [Email/phone OTP custom flow](https://clerk.com/docs/guides/development/custom-flows/authentication/email-sms-otp)
 - [useSignUp() reference](https://clerk.com/docs/references/react/use-sign-up)

--- a/skills/custom-ui/core-3/show-component.md
+++ b/skills/custom-ui/core-3/show-component.md
@@ -2,7 +2,7 @@
 
 The `<Show>` component conditionally renders content based on authentication state, roles, permissions, billing plans, and features.
 
-> **Core 2:** The `<Show>` component does not exist in Core 2. Use `<SignedIn>`, `<SignedOut>`, and `<Protect>` instead. See migration table below.
+> **Core 2 ONLY (skip if current SDK):** The `<Show>` component does not exist in Core 2. Use `<SignedIn>`, `<SignedOut>`, and `<Protect>` instead. See migration table below.
 
 ## Import
 

--- a/skills/custom-ui/core-3/show-component.md
+++ b/skills/custom-ui/core-3/show-component.md
@@ -1,0 +1,125 @@
+# `<Show>` Component
+
+The `<Show>` component conditionally renders content based on authentication state, roles, permissions, billing plans, and features.
+
+> **Core 2:** The `<Show>` component does not exist in Core 2. Use `<SignedIn>`, `<SignedOut>`, and `<Protect>` instead. See migration table below.
+
+## Import
+
+```typescript
+import { Show } from '@clerk/nextjs'       // Next.js
+import { Show } from '@clerk/react'         // React
+import { Show } from '@clerk/react-router'  // React Router
+import { Show } from '@clerk/expo'          // Expo
+```
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `when` | `string \| object \| function` | Condition for rendering children |
+| `fallback?` | `ReactNode` | Content shown when condition fails |
+| `treatPendingAsSignedOut?` | `boolean` | Treat pending sessions as signed-out (default: `true`) |
+
+## `when` Prop Variants
+
+### Authentication State
+
+```tsx
+// Show content only when signed in
+<Show when="signed-in">
+  <p>Welcome back!</p>
+</Show>
+
+// Show content only when signed out
+<Show when="signed-out">
+  <p>Please sign in.</p>
+</Show>
+```
+
+### Role Check
+
+```tsx
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
+```
+
+### Permission Check
+
+```tsx
+<Show when={{ permission: 'org:billing:manage' }}>
+  <BillingSettings />
+</Show>
+```
+
+### Billing Feature Check
+
+```tsx
+<Show when={{ feature: 'widgets' }}>
+  <WidgetBuilder />
+</Show>
+```
+
+### Billing Plan Check
+
+```tsx
+<Show when={{ plan: 'gold' }}>
+  <PremiumContent />
+</Show>
+```
+
+### Custom Condition (Function)
+
+```tsx
+<Show when={(has) => has({ role: 'org:admin' }) || has({ permission: 'org:billing:manage' })}>
+  <SettingsPanel />
+</Show>
+```
+
+## Fallback Content
+
+Show alternative content when the condition fails:
+
+```tsx
+<Show when="signed-in" fallback={<p>Please sign in to continue.</p>}>
+  <Dashboard />
+</Show>
+```
+
+## Session Tasks and Pending State
+
+The `treatPendingAsSignedOut` prop controls how pending sessions (sessions with incomplete tasks) are handled:
+
+```tsx
+// Default: pending sessions are treated as signed-out
+<Show when="signed-in" treatPendingAsSignedOut>
+  <Dashboard />
+</Show>
+
+// Treat pending sessions as signed-in (e.g., to show task completion UI)
+<Show when="signed-in" treatPendingAsSignedOut={false}>
+  <TaskCompletionFlow />
+</Show>
+```
+
+## Security Caveat
+
+**`<Show>` only visually hides content** — it remains in browser source. It is not a security boundary. For protecting sensitive data, always verify authentication server-side with `auth()` or use `auth.protect()` in middleware.
+
+## Migration from Core 2
+
+| Core 2 | Current |
+|--------|---------|
+| `<SignedIn>` | `<Show when="signed-in">` |
+| `<SignedOut>` | `<Show when="signed-out">` |
+| `<Protect role="org:admin">` | `<Show when={{ role: 'org:admin' }}>` |
+| `<Protect permission="org:billing:manage">` | `<Show when={{ permission: 'org:billing:manage' }}>` |
+| `<Protect condition={(has) => expr}>` | `<Show when={(has) => expr}>` |
+| `<Protect fallback={...}>` | `<Show when={...} fallback={...}>` |
+| *(no equivalent)* | `<Show when={{ feature: 'widgets' }}>` |
+| *(no equivalent)* | `<Show when={{ plan: 'gold' }}>` |
+
+## Docs
+
+- [Show component reference](https://clerk.com/docs/components/control/show)

--- a/skills/nextjs-patterns/.claude-plugin/plugin.json
+++ b/skills/nextjs-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clerk-nextjs-patterns",
   "description": "Advanced Next.js patterns - middleware, Server Actions, caching with Clerk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Clerk",
     "email": "support@clerk.com"

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 allowed-tools: WebFetch
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Next.js Patterns
@@ -36,6 +36,13 @@ Server vs Client = different auth APIs:
 
 Never mix them. Server Components use server imports, Client Components use hooks.
 
+Key properties from `auth()`:
+- `isAuthenticated` — boolean, replaces the `!!userId` pattern
+- `sessionStatus` — `'active'` | `'pending'`, for detecting incomplete session tasks
+- `userId`, `orgId`, `orgSlug`, `has()`, `protect()` — unchanged
+
+> **Core 2:** `isAuthenticated` and `sessionStatus` are not available. Check `!!userId` instead.
+
 ## Minimal Pattern
 
 ```typescript
@@ -43,11 +50,27 @@ Never mix them. Server Components use server imports, Client Components use hook
 import { auth } from '@clerk/nextjs/server'
 
 export default async function Page() {
-  const { userId } = await auth()  // MUST await!
-  if (!userId) return <p>Not signed in</p>
+  const { isAuthenticated, userId } = await auth()  // MUST await!
+  if (!isAuthenticated) return <p>Not signed in</p>
   return <p>Hello {userId}</p>
 }
 ```
+
+> **Core 2:** `isAuthenticated` is not available. Use `if (!userId)` instead.
+
+### Conditional Rendering with `<Show>`
+
+For client-side conditional rendering based on auth state:
+
+```tsx
+import { Show } from '@clerk/nextjs'
+
+<Show when="signed-in" fallback={<p>Please sign in</p>}>
+  <Dashboard />
+</Show>
+```
+
+> **Core 2:** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`. See `custom-ui/core-3/show-component.md` for the full migration table.
 
 ## Common Pitfalls
 

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -85,7 +85,7 @@ import { Show } from '@clerk/nextjs'
 ## See Also
 
 - `setup/`
-- `managing-orgs/`
+- `orgs/`
 
 ## Docs
 

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 
 # Next.js Patterns
 
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2:**` callouts.
+
 For basic setup, see `setup/`.
 
 ## Impact Levels

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # Next.js Patterns
 
-> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2:**` callouts.
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts.
 
 For basic setup, see `setup/`.
 
@@ -43,7 +43,7 @@ Key properties from `auth()`:
 - `sessionStatus` — `'active'` | `'pending'`, for detecting incomplete session tasks
 - `userId`, `orgId`, `orgSlug`, `has()`, `protect()` — unchanged
 
-> **Core 2:** `isAuthenticated` and `sessionStatus` are not available. Check `!!userId` instead.
+> **Core 2 ONLY (skip if current SDK):** `isAuthenticated` and `sessionStatus` are not available. Check `!!userId` instead.
 
 ## Minimal Pattern
 
@@ -58,7 +58,7 @@ export default async function Page() {
 }
 ```
 
-> **Core 2:** `isAuthenticated` is not available. Use `if (!userId)` instead.
+> **Core 2 ONLY (skip if current SDK):** `isAuthenticated` is not available. Use `if (!userId)` instead.
 
 ### Conditional Rendering with `<Show>`
 
@@ -72,7 +72,7 @@ import { Show } from '@clerk/nextjs'
 </Show>
 ```
 
-> **Core 2:** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`. See `custom-ui/core-3/show-component.md` for the full migration table.
+> **Core 2 ONLY (skip if current SDK):** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`. See `custom-ui/core-3/show-component.md` for the full migration table.
 
 ## Common Pitfalls
 

--- a/skills/nextjs-patterns/references/api-routes.md
+++ b/skills/nextjs-patterns/references/api-routes.md
@@ -15,7 +15,7 @@ export async function GET() {
 }
 ```
 
-> **Core 2:** `isAuthenticated` is not available. Use `if (!userId)` instead.
+> **Core 2 ONLY (skip if current SDK):** `isAuthenticated` is not available. Use `if (!userId)` instead.
 
 ## 401 vs 403
 

--- a/skills/nextjs-patterns/references/api-routes.md
+++ b/skills/nextjs-patterns/references/api-routes.md
@@ -6,14 +6,16 @@
 import { auth } from '@clerk/nextjs/server';
 
 export async function GET() {
-  const { userId } = await auth();
-  if (!userId) {
+  const { isAuthenticated, userId } = await auth();
+  if (!isAuthenticated) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const data = await db.data.findMany({ where: { userId } });
   return Response.json(data);
 }
 ```
+
+> **Core 2:** `isAuthenticated` is not available. Use `if (!userId)` instead.
 
 ## 401 vs 403
 
@@ -22,8 +24,8 @@ export async function GET() {
 
 ```typescript
 export async function DELETE(req: Request) {
-  const { userId, has } = await auth();
-  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  const { isAuthenticated, has } = await auth();
+  if (!isAuthenticated) return Response.json({ error: 'Unauthorized' }, { status: 401 });
 
   const isAdmin = await has({ role: 'org:admin' });
   if (!isAdmin) return Response.json({ error: 'Forbidden' }, { status: 403 });

--- a/skills/nextjs-patterns/references/middleware-strategies.md
+++ b/skills/nextjs-patterns/references/middleware-strategies.md
@@ -61,6 +61,6 @@ export default clerkMiddleware(async (auth, req) => {
 });
 ```
 
-> **Core 2:** `sessionStatus` is not available. Session tasks do not exist in Core 2.
+> **Core 2 ONLY (skip if current SDK):** `sessionStatus` is not available. Session tasks do not exist in Core 2.
 
 [Docs](https://clerk.com/docs/reference/nextjs/clerk-middleware)

--- a/skills/nextjs-patterns/references/middleware-strategies.md
+++ b/skills/nextjs-patterns/references/middleware-strategies.md
@@ -44,4 +44,23 @@ export default clerkMiddleware(async (auth, req) => {
 });
 ```
 
+## Session Tasks
+
+When session tasks are enabled (e.g., forced password reset, MFA setup), users may have a `pending` session status. You can handle this in middleware:
+
+```typescript
+export default clerkMiddleware(async (auth, req) => {
+  const { sessionStatus } = await auth();
+
+  // Redirect pending sessions to task completion page
+  if (sessionStatus === 'pending') {
+    return NextResponse.redirect(new URL('/sign-in/tasks', req.url));
+  }
+
+  if (isProtectedRoute(req)) await auth.protect();
+});
+```
+
+> **Core 2:** `sessionStatus` is not available. Session tasks do not exist in Core 2.
+
 [Docs](https://clerk.com/docs/reference/nextjs/clerk-middleware)

--- a/skills/nextjs-patterns/references/server-actions.md
+++ b/skills/nextjs-patterns/references/server-actions.md
@@ -9,8 +9,8 @@ Server Actions are public endpoints. Always verify auth.
 import { auth } from '@clerk/nextjs/server';
 
 export async function createPost(formData: FormData) {
-  const { userId } = await auth();
-  if (!userId) throw new Error('Unauthorized');
+  const { isAuthenticated, userId } = await auth();
+  if (!isAuthenticated) throw new Error('Unauthorized');
 
   const title = formData.get('title') as string;
   await db.posts.create({ data: { title, authorId: userId } });
@@ -50,5 +50,7 @@ export async function deleteProject(projectId: string) {
   await db.projects.delete({ where: { id: projectId } });
 }
 ```
+
+> **Core 2:** `isAuthenticated` is not available. Use `if (!userId)` instead.
 
 [Docs](https://clerk.com/docs/reference/nextjs/server-actions)

--- a/skills/nextjs-patterns/references/server-actions.md
+++ b/skills/nextjs-patterns/references/server-actions.md
@@ -51,6 +51,6 @@ export async function deleteProject(projectId: string) {
 }
 ```
 
-> **Core 2:** `isAuthenticated` is not available. Use `if (!userId)` instead.
+> **Core 2 ONLY (skip if current SDK):** `isAuthenticated` is not available. Use `if (!userId)` instead.
 
 [Docs](https://clerk.com/docs/reference/nextjs/server-actions)

--- a/skills/nextjs-patterns/references/server-vs-client.md
+++ b/skills/nextjs-patterns/references/server-vs-client.md
@@ -32,13 +32,15 @@ import { useAuth, useUser } from '@clerk/nextjs';
 import { auth, currentUser } from '@clerk/nextjs/server';
 
 export default async function DashboardPage() {
-  const { userId } = await auth();
-  if (!userId) return <div>Please sign in</div>;
+  const { isAuthenticated } = await auth();
+  if (!isAuthenticated) return <div>Please sign in</div>;
 
   const user = await currentUser();
   return <h1>Welcome, {user?.firstName}!</h1>;
 }
 ```
+
+> **Core 2:** `isAuthenticated` is not available. Use `const { userId } = await auth()` and check `if (!userId)` instead.
 
 ## Client Component
 
@@ -84,5 +86,19 @@ export function ProfileForm({ initialData }) {
   return <form>...</form>;
 }
 ```
+
+## Conditional Rendering
+
+Use `<Show>` for client-side conditional rendering based on auth state:
+
+```tsx
+import { Show } from '@clerk/nextjs';
+
+<Show when="signed-in" fallback={<div>Please sign in</div>}>
+  <Dashboard />
+</Show>
+```
+
+> **Core 2:** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`.
 
 [Docs](https://clerk.com/docs/reference/nextjs/auth)

--- a/skills/nextjs-patterns/references/server-vs-client.md
+++ b/skills/nextjs-patterns/references/server-vs-client.md
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
 }
 ```
 
-> **Core 2:** `isAuthenticated` is not available. Use `const { userId } = await auth()` and check `if (!userId)` instead.
+> **Core 2 ONLY (skip if current SDK):** `isAuthenticated` is not available. Use `const { userId } = await auth()` and check `if (!userId)` instead.
 
 ## Client Component
 
@@ -99,6 +99,6 @@ import { Show } from '@clerk/nextjs';
 </Show>
 ```
 
-> **Core 2:** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`.
+> **Core 2 ONLY (skip if current SDK):** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`.
 
 [Docs](https://clerk.com/docs/reference/nextjs/auth)

--- a/skills/orgs/.claude-plugin/plugin.json
+++ b/skills/orgs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clerk-orgs",
   "description": "Clerk Organizations for B2B SaaS - create multi-tenant apps with org switching, role-based access, verified domains, and enterprise SSO. Use for team workspaces, RBAC, org-based routing, member management.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Clerk",
     "email": "support@clerk.com"

--- a/skills/orgs/SKILL.md
+++ b/skills/orgs/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 # Organizations (B2B SaaS)
 
 > **Prerequisite**: Enable Organizations in Clerk Dashboard first.
+>
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2:**` callouts.
 
 ## Quick Start
 

--- a/skills/orgs/SKILL.md
+++ b/skills/orgs/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Organizations (B2B SaaS)
@@ -152,6 +152,64 @@ export default async function AdminPage({ params }: { params: { slug: string } }
   return <div>Admin settings for {orgSlug}</div>
 }
 ```
+
+## Conditional Rendering with `<Show>`
+
+Use `<Show>` for role-based conditional rendering in client components:
+
+```tsx
+import { Show } from '@clerk/nextjs'
+
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
+
+<Show when={{ permission: 'org:billing:manage' }}>
+  <BillingSettings />
+</Show>
+```
+
+> **Core 2:** Use `<Protect role="org:admin">` and `<Protect permission="org:billing:manage">` instead of `<Show>`.
+
+## Billing Checks
+
+The `has()` method supports billing plan and feature checks for gating access:
+
+```typescript
+const { has } = await auth()
+
+has({ plan: 'gold' })        // Check subscription plan
+has({ feature: 'widgets' })  // Check feature entitlement
+```
+
+> **Core 2:** `has()` only supports `role` and `permission` parameters. Billing checks are not available.
+
+## Session Tasks
+
+When personal accounts are disabled, users must choose an organization after sign-in. This is handled by the `choose-organization` session task:
+
+```tsx
+import { TaskChooseOrganization } from '@clerk/nextjs'
+
+// Renders when user must select an org
+<TaskChooseOrganization redirectUrlComplete="/dashboard" />
+```
+
+> **Core 2:** Session tasks are not available. Use `<OrganizationSwitcher>` for org selection.
+
+## Enterprise SSO
+
+Organizations can use Enterprise SSO (SAML/OIDC) for member authentication:
+
+```typescript
+// Strategy name for Enterprise SSO
+strategy: 'enterprise_sso'
+
+// Access enterprise accounts on user object
+user.enterpriseAccounts
+```
+
+> **Core 2:** Uses `strategy: 'saml'` instead of `strategy: 'enterprise_sso'`, and `user.samlAccounts` instead of `user.enterpriseAccounts`.
 
 ## Common Pitfalls
 

--- a/skills/orgs/SKILL.md
+++ b/skills/orgs/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 > **Prerequisite**: Enable Organizations in Clerk Dashboard first.
 >
-> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2:**` callouts.
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts.
 
 ## Quick Start
 
@@ -171,7 +171,7 @@ import { Show } from '@clerk/nextjs'
 </Show>
 ```
 
-> **Core 2:** Use `<Protect role="org:admin">` and `<Protect permission="org:billing:manage">` instead of `<Show>`.
+> **Core 2 ONLY (skip if current SDK):** Use `<Protect role="org:admin">` and `<Protect permission="org:billing:manage">` instead of `<Show>`.
 
 ## Billing Checks
 
@@ -184,7 +184,7 @@ has({ plan: 'gold' })        // Check subscription plan
 has({ feature: 'widgets' })  // Check feature entitlement
 ```
 
-> **Core 2:** `has()` only supports `role` and `permission` parameters. Billing checks are not available.
+> **Core 2 ONLY (skip if current SDK):** `has()` only supports `role` and `permission` parameters. Billing checks are not available.
 
 ## Session Tasks
 
@@ -197,7 +197,7 @@ import { TaskChooseOrganization } from '@clerk/nextjs'
 <TaskChooseOrganization redirectUrlComplete="/dashboard" />
 ```
 
-> **Core 2:** Session tasks are not available. Use `<OrganizationSwitcher>` for org selection.
+> **Core 2 ONLY (skip if current SDK):** Session tasks are not available. Use `<OrganizationSwitcher>` for org selection.
 
 ## Enterprise SSO
 
@@ -211,7 +211,7 @@ strategy: 'enterprise_sso'
 user.enterpriseAccounts
 ```
 
-> **Core 2:** Uses `strategy: 'saml'` instead of `strategy: 'enterprise_sso'`, and `user.samlAccounts` instead of `user.enterpriseAccounts`.
+> **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` instead of `strategy: 'enterprise_sso'`, and `user.samlAccounts` instead of `user.enterpriseAccounts`.
 
 ## Common Pitfalls
 

--- a/skills/setup/.claude-plugin/plugin.json
+++ b/skills/setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clerk-setup",
   "description": "Add Clerk authentication to any project by following the official quickstart guides",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Clerk",
     "email": "support@clerk.com"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 allowed-tools: WebFetch
 metadata:
   author: clerk
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Adding Clerk
@@ -143,6 +143,63 @@ Check `package.json` for existing auth libraries:
 
 - **Migration Overview**: https://clerk.com/docs/guides/development/migrating/overview
 
+## SDK Notes
+
+### Package Names
+
+| Package | Install |
+|---------|---------|
+| Next.js | `@clerk/nextjs` |
+| React | `@clerk/react` |
+| Expo | `@clerk/expo` |
+| React Router | `@clerk/react-router` |
+| TanStack Start | `@clerk/tanstack-react-start` |
+
+> **Core 2:** React and Expo packages have different names: `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix).
+
+### ClerkProvider Placement (Next.js)
+
+`ClerkProvider` must be placed **inside `<body>`**, not wrapping `<html>`:
+
+```tsx
+// root layout.tsx
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <ClerkProvider>{children}</ClerkProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+> **Core 2:** `ClerkProvider` can wrap `<html>` directly.
+
+### Dynamic Rendering (Next.js)
+
+For dynamic rendering with auth data, use the `dynamic` prop:
+
+```tsx
+<ClerkProvider dynamic>{children}</ClerkProvider>
+```
+
+### Node.js Requirement
+
+Requires **Node.js 20.9.0** or higher.
+
+> **Core 2:** Minimum Node.js 18.17.0.
+
+### Themes Package
+
+Themes are installed from `@clerk/ui`:
+
+```bash
+npm install @clerk/ui
+```
+
+> **Core 2:** Themes are from `@clerk/themes` instead of `@clerk/ui`.
+
 ## Common Pitfalls
 
 | Level | Issue | Solution |
@@ -150,10 +207,11 @@ Check `package.json` for existing auth libraries:
 | CRITICAL | Missing `await` on `auth()` | In Next.js 15+, `auth()` is async: `const { userId } = await auth()` |
 | CRITICAL | Exposing `CLERK_SECRET_KEY` | Never use secret key in client code; only `NEXT_PUBLIC_*` keys are safe |
 | HIGH | Missing middleware matcher | Include API routes: `matcher: ['/((?!.*\\..*|_next).*)', '/']` |
-| HIGH | ClerkProvider not at root | Must wrap entire app in root layout/App component |
+| HIGH | ClerkProvider placement | Must be inside `<body>` in root layout (Core 2: could wrap `<html>`) |
 | HIGH | Auth routes not public | Allow `/sign-in`, `/sign-up` in middleware config |
 | HIGH | Landing page requires auth | To keep "/" public, exclude it: `matcher: ['/((?!.*\\..*|_next|^/$).*)', '/api/(.*)']` |
 | MEDIUM | Wrong import path | Server code uses `@clerk/nextjs/server`, client uses `@clerk/nextjs` |
+| MEDIUM | Wrong package name | Use `@clerk/react` not `@clerk/clerk-react` (Core 2 naming) |
 
 ## See Also
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -215,9 +215,9 @@ npm install @clerk/ui
 
 ## See Also
 
-- `custom-flows/` - Custom sign-in/up components
-- `syncing-users/` - Webhook → database sync
-- `managing-orgs/` - B2B multi-tenant organizations
+- `custom-ui/` - Custom sign-in/up components
+- `webhooks/` - Webhook → database sync
+- `orgs/` - B2B multi-tenant organizations
 - `testing/` - E2E testing setup
 - `nextjs-patterns/` - Advanced Next.js patterns
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 
 # Adding Clerk
 
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2:**` callouts.
+
 This skill sets up Clerk for authentication by following the official quickstart documentation.
 
 ## Quick Reference

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # Adding Clerk
 
-> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2:**` callouts.
+> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts.
 
 This skill sets up Clerk for authentication by following the official quickstart documentation.
 
@@ -157,7 +157,7 @@ Check `package.json` for existing auth libraries:
 | React Router | `@clerk/react-router` |
 | TanStack Start | `@clerk/tanstack-react-start` |
 
-> **Core 2:** React and Expo packages have different names: `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix).
+> **Core 2 ONLY (skip if current SDK):** React and Expo packages have different names: `@clerk/clerk-react` and `@clerk/clerk-expo` (with `clerk-` prefix).
 
 ### ClerkProvider Placement (Next.js)
 
@@ -176,7 +176,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-> **Core 2:** `ClerkProvider` can wrap `<html>` directly.
+> **Core 2 ONLY (skip if current SDK):** `ClerkProvider` can wrap `<html>` directly.
 
 ### Dynamic Rendering (Next.js)
 
@@ -190,7 +190,7 @@ For dynamic rendering with auth data, use the `dynamic` prop:
 
 Requires **Node.js 20.9.0** or higher.
 
-> **Core 2:** Minimum Node.js 18.17.0.
+> **Core 2 ONLY (skip if current SDK):** Minimum Node.js 18.17.0.
 
 ### Themes Package
 
@@ -200,7 +200,7 @@ Themes are installed from `@clerk/ui`:
 npm install @clerk/ui
 ```
 
-> **Core 2:** Themes are from `@clerk/themes` instead of `@clerk/ui`.
+> **Core 2 ONLY (skip if current SDK):** Themes are from `@clerk/themes` instead of `@clerk/ui`.
 
 ## Common Pitfalls
 


### PR DESCRIPTION

## Summary

Updates all skills to reflect the new Clerk SDK (Core 3) as the default, with inline `> **Core 2:**` callouts where behavior differs.

**Conventions:**
- All skills are written as if Core 3 is "the current way"
- When Core 2 differs, it's noted inline with `> **Core 2:**` blockquote callouts
- Exception: `custom-ui/` has separate `core-2/` and `core-3/` directories for custom flow hooks (`useSignIn`/`useSignUp`) since those APIs are entirely rewritten between versions
- Version detection table lives in the clerk router skill so agents see it as early as possible

## Changes

**Router (`clerk/SKILL.md`)**
- Added SDK version detection table at the top of the routing skill
- Documents the inline Core 2 callout convention and the `custom-ui/` exception

**Setup (`setup/SKILL.md`)**
- Added SDK Notes section: package renames (`@clerk/clerk-react` → `@clerk/react`, `@clerk/clerk-expo` → `@clerk/expo`), `ClerkProvider` must be inside `<body>`, `dynamic` prop, Node.js 20.9.0+ requirement, themes from `@clerk/ui`
- Updated pitfalls table with ClerkProvider placement and wrong package name

**Custom UI (`custom-ui/`)**
- Rewrote SKILL.md with appearance updates (`layout` → `options`, `@clerk/themes` → `@clerk/ui/themes`, theme stacking, `color-scheme` support, opacity changes for `colorRing`/`colorModalBackdrop`)
- Added `core-3/` references: `custom-sign-in.md` (SignInFuture API, namespaced methods, finalize(), structured errors), `custom-sign-up.md` (SignUpFuture API), `show-component.md` (`<Show>` replaces `<SignedIn>`/`<SignedOut>`/`<Protect>`)
- Added `core-2/` references: `custom-sign-in.md`, `custom-sign-up.md` (preserves existing create/prepare/attempt patterns)

**Next.js Patterns (`nextjs-patterns/`)**
- Added `isAuthenticated` boolean and `sessionStatus` to mental model and code examples
- Added `<Show>` component section with Core 2 callout
- Updated server-vs-client, server-actions, api-routes references with `isAuthenticated`
- Added Session Tasks section to middleware-strategies

**Organizations (`orgs/SKILL.md`)**
- Added `<Show>` for role-based rendering (replaces `<Protect>`)
- Added billing with `has({ plan, feature })`
- Added session tasks (`<TaskChooseOrganization>`)
- Added enterprise SSO naming (`enterprise_sso` vs `saml`)

**Metadata**
- Bumped changed skills to v2.0.0 in plugin.json files and marketplace.json
- Updated descriptions and keywords for custom-ui

Closes [USER-4819](https://linear.app/clerk/issue/USER-4819/update-clerk-skills-for-core-3)
