### PR TITLE
feat: add type-gen skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,6 +130,21 @@
       "license": "MIT",
       "category": "authentication",
       "keywords": ["clerk", "api", "backend", "rest", "openapi", "bapi"]
+    },
+    {
+      "name": "clerk-type-gen",
+      "description": "Generate and sync TypeScript types and constants for roles, permissions, features, and plans from your Clerk dashboard",
+      "version": "1.0.0",
+      "author": {
+        "name": "Clerk",
+        "email": "support@clerk.com"
+      },
+      "source": "./.claude/skills/clerk-type-gen",
+      "homepage": "https://clerk.com/docs",
+      "repository": "https://github.com/clerk/skills",
+      "license": "MIT",
+      "category": "authentication",
+      "keywords": ["clerk", "types", "codegen", "typescript"]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ skills/
 │   ├── managing-orgs/        # B2B multi-tenant organizations
 │   ├── nextjs-patterns/      # Advanced Next.js patterns
 │   ├── syncing-users/        # Webhook → database sync
-│   └── testing/              # E2E testing setup
+│   ├── testing/              # E2E testing setup
+│   ├── backend-api/          # Backend REST API explorer
+│   └── type-gen/             # Type generation from dashboard
 └── README.md                 # User-facing documentation
 ```
 
@@ -32,7 +34,8 @@ User Request
     ├─ "Organizations/RBAC" → managing-orgs/
     ├─ "Sync users to DB"   → syncing-users/
     ├─ "Write tests"        → testing/
-    └─ "Next.js patterns"   → nextjs-patterns/
+    ├─ "Next.js patterns"   → nextjs-patterns/
+    └─ "Sync types/roles"   → type-gen/
 ```
 
 ### Skill Structure

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ git clone https://github.com/clerk/skills ~/.claude/skills/clerk
 | `clerk-webhooks`        | Real-time events and data syncing            | Webhooks, database sync, notifications | Data Sync          |
 | `clerk-testing`         | E2E testing for auth flows                   | Writing Playwright/Cypress tests       | Testing            |
 | `/clerk-backend-api`    | Clerk Backend REST API explorer & executor   | Browsing or calling backend API endpoints | API Tool           |
+| `/clerk-type-gen`       | Generate & sync types from Clerk dashboard   | Syncing roles, permissions, plans as TypeScript types | Code Gen           |
 
 ## Quick Start
 
@@ -81,6 +82,7 @@ CLERK_SECRET_KEY=sk_test_xxx
 | "Set up organizations for my B2B app"    | `clerk-orgs`            |
 | "Use Server Actions with Clerk"          | `clerk-nextjs-patterns` |
 | "List all users via the Backend API"     | `clerk-backend-api`     |
+| "Sync my roles and permissions as types" | `clerk-type-gen`        |
 
 
 ## Repository Structure
@@ -122,6 +124,10 @@ For agents that support slash commands (Claude Code, OpenCode):
 /clerk-backend-api tags
 /clerk-backend-api GET /users
 /clerk-backend-api Users
+
+/clerk-type-gen
+/clerk-type-gen roles
+/clerk-type-gen permissions
 ```
 
 ## Resources

--- a/skills/backend-api/scripts/execute-request.sh
+++ b/skills/backend-api/scripts/execute-request.sh
@@ -11,14 +11,23 @@
 
 set -euo pipefail
 
-# Source env files from working directory (.env first, .env.local overrides)
-for envfile in "${PWD}/.env" "${PWD}/.env.local"; do
-  if [[ -f "$envfile" ]]; then
-    set -a
-    source "$envfile"
-    set +a
-  fi
+# Walk up from $PWD to find .env/.env.local (mirrors Clerk CLI behavior).
+# Stops at the first directory that provides CLERK_SECRET_KEY.
+_dir="$PWD"
+while true; do
+  for _envfile in "$_dir/.env" "$_dir/.env.local"; do
+    if [[ -f "$_envfile" ]]; then
+      set -a
+      source "$_envfile"
+      set +a
+    fi
+  done
+  [[ -n "${CLERK_SECRET_KEY:-}" ]] && break
+  _parent="$(dirname "$_dir")"
+  [[ "$_parent" == "$_dir" ]] && break
+  _dir="$_parent"
 done
+unset _dir _parent _envfile
 
 # Parse --admin flag
 ADMIN=false

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -46,6 +46,10 @@ Based on what you're trying to do, here's the right skill to use:
 - Inspect endpoint schemas
 - Execute API requests with scope enforcement
 
+**Type Generation** → Use `clerk-type-gen`
+- Generate types for roles, permissions, billing and more
+- Sync with latest data from dashboard
+
 ## Quick Navigation
 
 If you know your task, you can directly access:
@@ -56,5 +60,6 @@ If you know your task, you can directly access:
 - `/clerk-webhooks` - Webhooks
 - `/clerk-testing` - Testing
 - `/clerk-backend-api` - Backend REST API
+- `/clerk-type-gen` - Typescript types generation
 
 Or describe what you need and I'll recommend the right one.

--- a/skills/type-gen/.claude-plugin/plugin.json
+++ b/skills/type-gen/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+    "name": "clerk-type-gen",
+    "description": "Clerk Type Generator - generate and sync types for permissions, roles and more from your Clerk dashboard",
+    "version": "1.0.0",
+    "author": {
+      "name": "Clerk",
+      "email": "support@clerk.com"
+    },
+    "license": "MIT",
+    "homepage": "https://clerk.com/docs",
+    "repository": "https://github.com/clerk/skills",
+    "keywords": ["clerk", "api", "type-gen", "typescript", "types"],
+    "category": "authentication"
+  }
+  

--- a/skills/type-gen/SKILL.md
+++ b/skills/type-gen/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: clerk-type-gen
+description: "Generate and sync types for permissions, roles and more from your Clerk dashboard"
+argument-hint: "[category]"
+allowed-tools: Read, Write, Skill, Glob, Grep
+---
+
+## Options context
+
+User Prompt: $ARGUMENTS
+
+## Flags
+
+Parse these from the user prompt before determining mode:
+- `--dry-run` / `dry run` — print output without writing to filesystem
+- `--overwrite` — bypass file overwrite confirmation
+- `--out <dir>` — custom output directory
+
+## Your Task
+
+**IMPORTANT:** This skill is a multi-step pipeline that can run sub-skills as intermediate steps. You MUST complete ALL steps in sequence — do NOT stop after fetching data or running sub-skills.
+
+**Rules:**
+- Follow all steps in their sequential order unless explicitly instructed to skip.
+- Do NOT read reference files or templates ahead of when they are needed. Only read a file at the step that requires it.
+
+---
+
+### 0. Help Check
+
+If prompt contains only `help` / `-h` / `--help`, print the following verbatim (without additional commentary) and **stop**:
+
+Generate typescript types or constants from your Clerk dashboard and keep them in sync.
+
+```
+Commands
+  /clerk-type-gen                    — Sync all categories (or init if first run)
+  /clerk-type-gen sync               — Same as above
+  /clerk-type-gen init               — Initialize output dir with all types & constants
+  /clerk-type-gen roles              — Generate types for roles & rolesets
+  /clerk-type-gen permissions        — Generate types for permissions
+  /clerk-type-gen features           — Generate types for features
+  /clerk-type-gen plans              — Generate types for billing plans
+
+Options
+  --overwrite                        — Bypass file overwrite confirmation
+  --out <dir>                        — Output directory (defaults to '.generated/clerk')
+  --help, -h, help                   — Print skill information and examples
+  --dry-run, dry run                 — Print output without writing to filesystem
+```
+
+---
+
+### 1. Resolve Output Directory & Determine Mode
+
+Resolve the output directory **first**, then determine the mode.
+
+#### Step 1a: Resolve output directory
+1. If `--out <dir>` was provided, use that directory.
+2. Otherwise, scan the project for an existing `.generated` directory. If found, ask the user: "Found `.generated` at `<path>` — use this for output?"
+3. If no directory was found or the user declined, default to `.generated/clerk/` in the project root.
+
+#### Step 1b: Determine mode
+
+| Prompt contains | Output dir exists? | Resolved mode |
+|-----------------|--------------------|---------------|
+| `init` | — | `init` |
+| specific categories (`roles`, `permissions`, `features`, `plans`) | — | `category` |
+| `sync`, empty prompt, or no args | **yes** | `sync` |
+| `sync`, empty prompt, or no args | **no** | `init` |
+
+---
+
+### 2. Fetch Category Data
+
+Fetch data via `Skill clerk-backend-api` using the query mapped to each requested category:
+
+| Category | Query |
+|----------|-------|
+| `roles` | `"fetch all roles and rolesets"` |
+| `permissions` | `"fetch all permissions"` |
+| `plans` / `features` | `"fetch all plans"` |
+
+For `init` and `sync` modes, fetch everything in a single query: `"fetch all roles, rolesets, permissions and plans"`.
+
+When multiple individual categories are requested, combine them into a single query (e.g. `roles` + `permissions` → `"fetch all roles, rolesets, and permissions"`).
+
+**IMPORTANT:** The Skill call above is a data-fetching step only. Once it returns, you MUST immediately continue to Step 3 using the returned data. Do NOT stop or summarize here.
+
+---
+
+### 3. Generate Output
+
+For each applicable output file, **read the template file first**, then generate the output using the fetched data and the template.
+
+**Output files**
+
+| File | Template to read | Generated when |
+|------|------------------|----------------|
+| `types.ts` | [Types Template](./references/types-template.md) | Always (all modes) |
+| `constants.ts` | [Constants Template](./references/const-template.md) | `init`, `sync`, or when `plans` and/or `roles` categories are requested |
+
+**Steps:**
+1. Read each applicable template file using the Read tool. Do NOT rely on prior conversation context — always read the file fresh.
+2. Generate the output content by applying the fetched data to the template structure.
+3. Only generate the sections relevant to the requested categories. For `init` and `sync` modes, generate all sections.
+
+**Formatting rules**
+- **Use JSDoc comments** — Each type must have a `/** type TypeName */` comment above it, matching the template examples.
+- **Use tabs for indentation** — All union members must be indented with tabs and prefixed with `|`.
+- Only include types relevant to the requested categories.
+
+If `dry-run` mode, stop here and print output. Otherwise proceed to [Write to Filesystem](#4-write-to-filesystem).
+
+---
+
+### 4. Write to Filesystem
+
+If in `dry-run` mode, skip this step.
+
+#### Init mode
+Create the output directory if it doesn't exist, then write all generated files.
+
+#### Sync and category modes
+For each generated file (`types.ts`, `constants.ts` if applicable):
+
+1. **If the file does not exist:** write it directly.
+2. **If the file exists:** read it and compare against the generated output.
+   - For `sync`: compare the entire file.
+   - For `category`: compare only the relevant sections for the requested categories.
+3. **If there are no differences:** tell the user "`<filename>` is already up to date." and skip that file.
+4. **If there are differences:**
+   - If `--overwrite` was passed: write immediately.
+   - For `sync`: ask the user "This will overwrite `<filename>`, proceed?"
+   - For `category`: for each changed section, ask the user "This will overwrite the `<category>` section in `<filename>`, proceed?" Only replace confirmed sections, preserving all other sections intact.

--- a/skills/type-gen/references/const-template.md
+++ b/skills/type-gen/references/const-template.md
@@ -1,0 +1,30 @@
+# Constants Template
+
+Follow this template **exactly** when generating constants. Do not deviate from the structure, naming, or comments.
+
+```typescript
+import type { OrganizationRoleSet } from './types'
+
+export const PLAN_SLUGS = {
+  FREE: 'org:free',
+  PREMIUM: 'org:premium',
+} as const
+
+export const PLAN_NAME = {
+  'STARTER': 'org:free',
+  'PREMIUM': 'org:premium',
+} as const
+
+export const PLAN_IDS = {
+  FREE: 'cplan_36hioU2PW8tZhG4DOnSeSCD6QwE',
+  PREMIUM: 'cplan_36lD406x53ISsjiy1KBQN4ZsdBm',
+} as const
+
+export type PLAN_SLUG = typeof PLAN_SLUGS[keyof typeof PLAN_SLUGS]
+export type PLAN_KEY = keyof typeof PLAN_SLUGS
+
+export const PLAN_ROLE_SETS: Record<PLAN_SLUG, OrganizationRoleSet> = {
+  'org:free': 'role_set:default',
+  'org:premium': 'role_set:premium',
+} as const
+```

--- a/skills/type-gen/references/types-template.md
+++ b/skills/type-gen/references/types-template.md
@@ -1,0 +1,57 @@
+# Permissions Template
+
+Follow this template **exactly** when generating permission types. Do not deviate from the structure, naming, or comments.
+
+## Instructions
+
+1. **Separate system vs custom permissions** — Permissions with keys matching `org:sys_*` are **system** permissions. All others are **custom** permissions.
+2. **Group custom permissions by feature** — Extract the feature name from the key pattern `org:<feature>:<action>`. Create a separate named type for each feature group: `type <FeatureName>Permission` (PascalCase the feature name).
+3. **Compose types bottom-up:**
+   - `SystemPermission` — union of all `org:sys_*` keys
+   - `<Feature>Permission` — one type per custom feature group
+   - `CustomOrganizationPermission` — `Expand<Feature1Permission | Feature2Permission | ...>`
+   - `OrganizationPermission` — `Expand<SystemPermission | CustomOrganizationPermission>`
+4. **Use `Expand<T>` utility** — Always include the `Expand` helper at the top. It must be used in `CustomOrganizationPermission` and `OrganizationPermission`.
+
+## Example
+
+```typescript
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+
+/** type OrganizationRoleSet */
+export type OrganizationRoleSet = "role_set:pro" | "role_set:default";
+
+/** type OrganizationRole - union of all roles in all rolesets */
+export type OrganizationRole =
+	| "org:developer"
+	| "org:member"
+	| "org:admin";
+
+/** type OrganizationFeature - custom feature */
+export type OrganizationFeature =
+	| "feature1"
+	| "feature2"
+
+/** type SystemPermission */
+export type SystemPermission =
+	| "org:sys_feature1:action"
+	| "org:sys_feature1:action"
+	| "org:sys_feature2:action"
+	| "org:sys_feature2:action"
+
+/** type <FeatureName>Permission */
+export type Feature1Permission =
+	| "org:<feature1>:action"
+	| "org:<feature1>:action"
+export type Feature2Permission =
+	| "org:<feature2>:action"
+	| "org:<feature2>:action"
+
+/** type CustomOrganizationPermission - all custom/user-generated permissions  */
+export type CustomOrganizationPermission = Expand<Feature1Permission | Feature2Permission>;
+
+/** type OrganizationPermission - all permissions including system */
+export type OrganizationPermission = Expand<
+	SystemPermission | CustomOrganizationPermission
+>;
+```


### PR DESCRIPTION
### Summary
Adds a new /clerk-type-gen skill that generates and syncs TypeScript types and constants from the Clerk dashboard. 
Fetches roles, rolesets, permissions, features, and plans using the `clerk-backend-api` skill and outputs generated types that can be used for `global.d.ts` overrides, typed wrappers and utilities.

- Supports `--dry-run`, `--overwrite`, and `--out <dir` flags
- Generates `types.ts` and `constants.ts` 
- Diffs against existing files before writing — reports "already up to date" when nothing changed

**Slash command examples:**
- `/clerk-type-gen` (no args) — syncs all categories, or runs init on first use
- `/clerk-type-gen sync` — same as above
- `/clerk-type-gen roles` — generate types for roles & rolesets only
- `/clerk-type-gen permissions` — generate types for permissions only
- `/clerk-type-gen plans / features` — generate types for billing plans
