### PR TITLE
Add native Android skill documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "version": "1.0.0",
-    "description": "Complete Clerk authentication toolkit with router for setup, custom UI, Next.js patterns, organizations, webhooks, and testing"
+    "description": "Complete Clerk authentication toolkit with router for setup, custom UI, native iOS, native Android, Next.js patterns, organizations, webhooks, and testing"
   },
   "plugins": [
     {
@@ -130,6 +130,21 @@
       "license": "MIT",
       "category": "authentication",
       "keywords": ["swift", "ios", "swiftui", "native-mobile", "clerkkit", "apple-sign-in"]
+    },
+    {
+      "name": "clerk-android",
+      "description": "Native Android Clerk auth with source-driven Kotlin and Jetpack Compose patterns",
+      "version": "1.0.0",
+      "author": {
+        "name": "Clerk",
+        "email": "support@clerk.com"
+      },
+      "source": "./skills/android",
+      "homepage": "https://clerk.com/docs",
+      "repository": "https://github.com/clerk/skills",
+      "license": "MIT",
+      "category": "authentication",
+      "keywords": ["android", "kotlin", "jetpack-compose", "native-mobile", "clerk-android"]
     },
     {
       "name": "clerk-backend-api",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "version": "1.0.0",
-    "description": "Complete Clerk authentication toolkit with router for setup, custom UI, native iOS, native Android, Next.js patterns, organizations, webhooks, and testing"
+    "description": "Complete Clerk authentication toolkit with router for setup, custom UI, Next.js patterns, organizations, webhooks, testing, and native mobile (Swift and Android)"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ clerk-skills/
 │   │   └── SKILL.md
 │   ├── testing/                 # E2E testing
 │   │   └── SKILL.md
-│   ├── swift/                   # Native Swift/iOS auth
 │   ├── android/                 # Native Android auth
 │   │   └── SKILL.md
 │   ├── swift/                   # Native Swift/iOS auth

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ clerk-skills/
 │   │   └── SKILL.md
 │   ├── testing/                 # E2E testing
 │   │   └── SKILL.md
-│   ├── android/                 # Native Android auth
-│   │   └── SKILL.md
 │   ├── swift/                   # Native Swift/iOS auth
+│   │   └── SKILL.md
+│   ├── android/                 # Native Android auth
 │   │   └── SKILL.md
 │   └── backend-api/             # Backend REST API
 │       ├── SKILL.md

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ git clone https://github.com/clerk/skills ~/.claude/skills/clerk
 | `clerk-webhooks`        | Real-time events and data syncing            | Webhooks, database sync, notifications | Data Sync          |
 | `clerk-testing`         | E2E testing for auth flows                   | Writing Playwright/Cypress tests       | Testing            |
 | `clerk-swift`           | Native Swift/iOS auth with ClerkKit          | SwiftUI/UIKit auth in native iOS apps  | Native iOS         |
+| `clerk-android`         | Native Android auth with Clerk               | Kotlin/Compose auth in Android apps    | Native Android     |
 | `/clerk-backend-api`    | Clerk Backend REST API explorer & executor   | Browsing or calling backend API endpoints | API Tool           |
 
 ## Quick Start
@@ -82,6 +83,7 @@ CLERK_SECRET_KEY=sk_test_xxx
 | "Set up organizations for my B2B app"    | `clerk-orgs`            |
 | "Use Server Actions with Clerk"          | `clerk-nextjs-patterns` |
 | "Add Clerk auth to my SwiftUI iOS app"   | `clerk-swift`           |
+| "Add Clerk auth to my Android app"       | `clerk-android`         |
 | "List all users via the Backend API"     | `clerk-backend-api`     |
 
 ## Repository Structure
@@ -104,6 +106,9 @@ clerk-skills/
 │   ├── webhooks/                # Webhooks & data sync
 │   │   └── SKILL.md
 │   ├── testing/                 # E2E testing
+│   │   └── SKILL.md
+│   ├── swift/                   # Native Swift/iOS auth
+│   ├── android/                 # Native Android auth
 │   │   └── SKILL.md
 │   ├── swift/                   # Native Swift/iOS auth
 │   │   └── SKILL.md

--- a/commands/clerk.md
+++ b/commands/clerk.md
@@ -27,9 +27,9 @@ skill({ name: 'clerk' })
 
 Analyze $ARGUMENTS to determine:
 - **Task type**: setup, customize UI, sync data, test, orgs, troubleshoot
-- **Platform**: Web (Next.js, React, Express, Remix) or native iOS (Swift/SwiftUI)
+- **Platform**: Web (Next.js, React, Express, Remix), native iOS (Swift/SwiftUI), or native Android (Kotlin/Compose)
 
-If Expo or React Native is detected, do not route to `clerk-swift`.
+If Expo or React Native is detected, do not route to `clerk-swift` or `clerk-android`.
 
 Use decision trees in SKILL.md to select correct skill.
 
@@ -46,6 +46,7 @@ Based on task type, load the appropriate skill:
 | Multi-tenant | `managing-orgs/` | SKILL.md |
 | Next.js patterns | `nextjs-patterns/` | SKILL.md + relevant reference |
 | Native iOS / Swift auth | `swift/` | SKILL.md |
+| Native Android auth | `android/` | SKILL.md |
 
 ### Step 5: Execute task
 

--- a/skills/android/.claude-plugin/plugin.json
+++ b/skills/android/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "clerk-android",
+  "description": "Native Android Clerk auth with source-driven Kotlin and Jetpack Compose patterns",
+  "version": "1.0.0",
+  "author": {
+    "name": "Clerk",
+    "email": "support@clerk.com"
+  },
+  "license": "MIT",
+  "homepage": "https://clerk.com/docs",
+  "repository": "https://github.com/clerk/skills",
+  "keywords": ["android", "kotlin", "jetpack-compose", "native-mobile", "clerk-android"],
+  "category": "authentication"
+}

--- a/skills/android/SKILL.md
+++ b/skills/android/SKILL.md
@@ -2,6 +2,7 @@
 name: clerk-android
 description: Implement Clerk authentication for native Android apps using Kotlin and Jetpack Compose with clerk-android source-guided patterns. Use for prebuilt AuthView/UserButton or custom API-driven auth flows. Do not use for Expo or React Native projects.
 license: MIT
+allowed-tools: WebFetch
 metadata:
   author: clerk
   version: "1.0.0"

--- a/skills/android/SKILL.md
+++ b/skills/android/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: clerk-android
+description: Implement Clerk authentication for native Android apps using Kotlin and Jetpack Compose with clerk-android source-guided patterns. Use for prebuilt AuthView/UserButton or custom API-driven auth flows. Do not use for Expo or React Native projects.
+license: MIT
+metadata:
+  author: clerk
+  version: "1.0.0"
+---
+
+# Clerk Android (Native)
+
+This skill implements Clerk in native Android projects by following current `clerk-android` SDK and docs patterns.
+
+## Activation Rules
+
+Activate this skill when either condition is true:
+- The user explicitly asks for Android, Kotlin, Jetpack Compose, or native mobile Clerk implementation on Android.
+- The project appears to be native Android (for example `build.gradle(.kts)` with Android plugins, `AndroidManifest.xml`, `app/src/main/java`, Compose UI files).
+
+Do not activate this skill when either condition is true:
+- The project is Expo.
+- The project is React Native.
+
+If Expo/React Native signals are present, route to the general setup skill instead.
+
+## Quick Start
+
+| Step | Action |
+|------|--------|
+| 1 | Confirm project type is native Android and not Expo/React Native |
+| 2 | Determine flow type (`prebuilt` or `custom`) and load the matching reference file |
+| 3 | Ensure a real Clerk publishable key exists (or ask developer) |
+| 4 | Ensure correct Clerk artifacts are installed for the selected flow |
+| 5 | Read official Android quickstart and verify required setup (Native API, min SDK/Java, manifest, initialization) |
+| 6 | Inspect `clerk-android` source/sample patterns relevant to selected flow |
+| 7 | Implement flow by following only the selected reference checklist |
+
+## Decision Tree
+
+```text
+User asks for Clerk in Android/Kotlin
+    |
+    +-- Expo/React Native project detected?
+    |     |
+    |     +-- YES -> Do not use this skill
+    |     |
+    |     +-- NO -> Continue
+    |
+    +-- Existing auth UI detected?
+    |     |
+    |     +-- Prebuilt views detected -> Load references/prebuilt.md
+    |     |
+    |     +-- Custom flow detected -> Load references/custom.md
+    |     |
+    |     +-- New implementation -> Ask developer prebuilt/custom, then load matching reference
+    |
+    +-- Ensure publishable key and SDK initialization path
+    |
+    +-- Ensure correct Android artifacts are installed
+    |
+    +-- Verify quickstart prerequisites in project
+    |
+    +-- Implement using selected flow reference
+```
+
+## Flow References
+
+After flow type is known, load exactly one:
+- Prebuilt flow: [references/prebuilt.md](references/prebuilt.md)
+- Custom flow: [references/custom.md](references/custom.md)
+
+Do not blend the two references in a single implementation unless the developer explicitly asks for a hybrid approach.
+
+## Interaction Contract
+
+Before any implementation edits, the agent must have both:
+- flow choice: `prebuilt` or `custom`
+- a real Clerk publishable key
+
+If either value is missing from the user request/context:
+- ask the user for the missing value(s)
+- pause and wait for the answer
+- do not edit files or install dependencies yet
+
+Only skip asking when the user has already explicitly provided the value in this conversation.
+
+## Source-Driven Templates
+
+Do not hardcode implementation examples in this skill. Inspect current `clerk-android` source/docs for the installed SDK version before implementing.
+
+| Use Case | Source of Truth |
+|----------|-----------------|
+| SDK artifacts and dependency split (`clerk-android-api` vs `clerk-android-ui`) | `clerk-android` README and Android install docs |
+| SDK initialization and publishable key wiring | Android quickstart and `source/api/.../Clerk.kt` |
+| Prebuilt auth and profile behavior | `source/ui/.../AuthView.kt`, `source/ui/.../UserButton.kt`, and prebuilt sample |
+| Custom auth sequencing and factor handling | `source/ui/auth/*`, `source/api/auth/*`, and custom-flows sample |
+| Capability/feature gating from instance settings | `Clerk` public fields (for example `enabledFirstFactorAttributes`, `socialProviders`, `isGoogleOneTapEnabled`, `mfaIsEnabled`) and environment model source |
+| Required Android setup checklist | Official Android quickstart (`/docs/android/getting-started/quickstart`) |
+
+## Execution Gates (Do Not Skip)
+
+1. No implementation edits before prerequisites
+- Do not edit project files until flow type is confirmed and a valid publishable key is available.
+
+2. Missing flow or key must trigger a question
+- If flow choice is missing, explicitly ask: prebuilt views or custom flow.
+- If publishable key is missing/placeholder/invalid, explicitly ask for a real key.
+- Do not continue until both answers are provided.
+
+3. Publishable key wiring mode is mandatory
+- By default, wire the developer-provided key directly in `Clerk.initialize(...)`.
+- Do not introduce secret-management indirection unless explicitly requested.
+
+4. Artifact install policy is mandatory
+- Prebuilt flow: use `clerk-android-ui` (includes API).
+- Custom flow: use `clerk-android-api` unless prebuilt components are explicitly requested.
+- If Clerk artifacts are missing, add the latest stable release available.
+
+5. Android quickstart compliance is mandatory
+- Verify Native API is enabled for the Clerk app.
+- Verify Android requirements from quickstart are implemented in project (minimum SDK and Java target, manifest internet permission, app-level Clerk initialization).
+- Verify app waits for SDK initialization (`Clerk.isInitialized`) before assuming auth-ready state.
+
+6. Capability-driven behavior is mandatory
+- Use Clerk runtime capability/settings state (for example enabled factors/social providers/MFA flags) to gate flow behavior.
+- Do not hardcode factor assumptions that may conflict with dashboard configuration.
+
+7. Reference-file discipline is mandatory
+- Once flow is selected, follow only that flow reference file for implementation and verification.
+
+8. Custom-flow structure parity is mandatory
+- For `custom` flow, preserve multi-step auth progression and factor-specific handling (no single all-fields form by default).
+- Keep UI, state orchestration, and Clerk API integration in separate modules.
+
+9. Prebuilt preference is mandatory when selected
+- For `prebuilt` flow, do not rebuild auth forms with custom API calls unless explicitly requested.
+- Use `AuthView`/`UserButton` as default building blocks.
+
+## Workflow
+
+1. Detect native Android vs Expo/React Native.
+2. If flow type is not explicitly provided, ask user for `prebuilt` or `custom`.
+3. If publishable key is not explicitly provided, ask user for it.
+4. Wait for both answers before changing files.
+5. Load matching flow reference file.
+6. Ensure `Clerk.initialize(...)` path and publishable key wiring are valid.
+7. Ensure dependencies/artifacts match selected flow.
+8. Review Android quickstart requirements and apply missing setup in project.
+9. Implement using selected reference checklist.
+10. Verify using selected reference checklist plus shared gates.
+
+## Common Pitfalls
+
+| Level | Issue | Prevention |
+|-------|-------|------------|
+| CRITICAL | Not asking for missing flow choice before implementation | Ask for `prebuilt` vs `custom` and wait before edits |
+| CRITICAL | Not asking for missing publishable key before implementation | Ask for key and wait before edits |
+| CRITICAL | Starting implementation before flow type is confirmed | Confirm flow first and load matching reference |
+| CRITICAL | Skipping Android quickstart prerequisites | Verify and apply required setup from official Android quickstart |
+| CRITICAL | Missing app-level `Clerk.initialize(...)` call | Initialize Clerk from `Application` startup path |
+| HIGH | Wrong artifact for chosen flow | Prebuilt: `clerk-android-ui`; custom: `clerk-android-api` |
+| HIGH | Rendering auth UI before SDK initialization completes | Gate UI with `Clerk.isInitialized` state |
+| HIGH | Hardcoding auth factors/social providers | Drive behavior from Clerk runtime capability fields |
+| HIGH | Using this skill for Expo/React Native | Detect and route away before implementation |
+
+## See Also
+
+- `../clerk/SKILL.md` for top-level Clerk routing
+- `../setup/SKILL.md` for cross-framework quickstart setup
+- `https://github.com/clerk/clerk-android`
+- `https://clerk.com/docs/android/getting-started/quickstart`

--- a/skills/android/references/custom.md
+++ b/skills/android/references/custom.md
@@ -1,0 +1,93 @@
+# Custom Flow Reference (Clerk Android API)
+
+Use this file only when flow type is `custom`.
+
+## Purpose
+
+Implement native Android auth with Clerk API primitives while preserving Clerk's multi-step auth semantics and dashboard-driven capability gating.
+
+## Source-Driven Requirements
+
+Use current `clerk-android` source/docs as primary references:
+- `source/api` for sign-in/sign-up/session/auth APIs.
+- `source/ui/auth` and `samples/custom-flows` for flow sequencing patterns.
+- Android quickstart for required project setup.
+
+Source priority rules for custom flow:
+- Primary source: Clerk Android API and auth flow source.
+- Secondary source: `samples/custom-flows`.
+- Fallback only: high-level docs when behavior is unclear from SDK/source.
+
+## Required Patterns
+
+1. Artifact selection
+- Ensure `com.clerk:clerk-android-api` is installed.
+- Do not add `clerk-android-ui` unless developer explicitly asks for a hybrid prebuilt/custom approach.
+
+2. Quickstart prerequisite audit
+- Read the official Android quickstart: `https://clerk.com/docs/android/getting-started/quickstart`.
+- Verify required project setup (Native API, min SDK/Java, manifest internet permission, app-level initialization).
+- Implement missing required setup before finishing custom auth work.
+
+3. Initialization and state contract
+- Initialize via `Clerk.initialize(...)` at app startup.
+- Wait for `Clerk.isInitialized` before treating Clerk as ready.
+- Drive session/user UI from `Clerk.userFlow`/`Clerk.sessionFlow`.
+
+4. Capability-driven flow logic
+- Use Clerk runtime capability/settings fields to drive flow branches (first factors, social providers, MFA, Google One Tap support).
+- Do not hardcode fixed factor/provider assumptions.
+
+5. Multi-step flow progression
+- Keep sign-in/sign-up progression split into explicit steps/states.
+- Avoid collapsing all required auth input into one monolithic screen.
+- Keep branching aligned with factor requirements and verification states returned by Clerk.
+
+6. API usage patterns
+- Use Clerk sign-in/sign-up APIs and verification methods with structured success/failure handling.
+- Keep request/response handling explicit and status-driven.
+- Use Clerk error helpers/messages for user-visible errors.
+
+7. OAuth/social policy
+- Use provider flows supported by Clerk APIs.
+- For Google, honor runtime One Tap capability and use the appropriate Clerk path.
+- Do not bypass Clerk by implementing provider-specific token exchange directly unless explicitly requested.
+
+8. Code organization and separation of concerns
+- Split custom auth into focused modules:
+  - UI step views/components
+  - Flow/state orchestration (view models/state machines)
+  - Clerk API integration layer
+- Keep module boundaries clear and composable.
+
+9. Avoid hidden dependencies
+- Do not silently add prebuilt UI dependencies to custom-only implementations.
+- Do not introduce local config indirection for publishable key unless requested.
+
+## Verification Checklist
+
+1. Quickstart prerequisites are complete
+- Required Android/Clerk setup from quickstart is present.
+- Missing required setup was applied.
+
+2. Correct artifact usage
+- `clerk-android-api` is present.
+- `clerk-android-ui` is absent unless explicitly required.
+
+3. Initialization and auth state handling
+- UI/runtime waits for `Clerk.isInitialized`.
+- Auth/session/user state derives from Clerk flows.
+
+4. Capability-driven behavior
+- Flow branches align with runtime capabilities and dashboard configuration.
+- No hardcoded factor/provider matrix independent of Clerk state.
+
+5. Multi-step auth quality
+- Flow uses explicit steps with clear transitions.
+- Required fields and verifications are fully covered.
+
+6. Architecture quality
+- UI, orchestration, and Clerk integration are separated into focused files/modules.
+
+7. OAuth/social correctness
+- OAuth handling uses Clerk APIs and supported provider paths.

--- a/skills/android/references/prebuilt.md
+++ b/skills/android/references/prebuilt.md
@@ -1,0 +1,63 @@
+# Prebuilt Flow Reference (Clerk Android UI)
+
+Use this file only when flow type is `prebuilt`.
+
+## Purpose
+
+Implement native Android auth with Clerk prebuilt Compose views (`AuthView`, `UserButton`) instead of building custom auth UI logic.
+
+## Required Patterns
+
+1. Artifact selection
+- Ensure `com.clerk:clerk-android-ui` is installed (it includes API artifact transitively).
+- Do not add `clerk-android-api` separately unless the project explicitly needs it.
+- Use the latest stable release unless the developer requests a specific version.
+
+2. Quickstart prerequisite audit
+- Read the official Android quickstart: `https://clerk.com/docs/android/getting-started/quickstart`.
+- Verify required setup is present:
+  - Native API is enabled in Clerk Dashboard.
+  - Project min SDK and Java target meet Clerk Android requirements.
+  - `android.permission.INTERNET` is present in `AndroidManifest.xml`.
+  - App-level initialization calls `Clerk.initialize(...)` in `Application` startup.
+- If any required setup is missing, implement it before finishing prebuilt auth work.
+
+3. Initialization and state gating
+- Treat SDK initialization as async/non-blocking.
+- Gate signed-in/signed-out rendering using `Clerk.isInitialized` and `Clerk.userFlow`.
+- Show loading while initialization is in progress.
+
+4. Signed-in/out presentation pattern
+- Default signed-out UI: `AuthView()`.
+- Default signed-in UI: `UserButton()` (or app content with `UserButton` entry point).
+- Keep `AuthView()` in combined sign-in-or-sign-up behavior unless explicitly requested otherwise.
+
+5. Capability alignment
+- If social/OAuth options appear inconsistent with expected behavior, verify dashboard config and runtime capability fields (`Clerk.socialProviders`, `Clerk.isGoogleOneTapEnabled`, MFA flags).
+- Do not hardcode provider availability.
+
+6. Minimal customization by default
+- Do not replace prebuilt views with custom forms unless the developer asks for custom flow.
+- Keep customization focused on layout placement/theme integration.
+
+## Verification Checklist
+
+1. Quickstart prerequisites are complete
+- Native API enabled.
+- Required Android project setup from quickstart is present.
+- Missing required prerequisites were applied, not only reported.
+
+2. Correct prebuilt artifact usage
+- `clerk-android-ui` is installed.
+- Versioning follows latest stable by default.
+
+3. Auth UI gating correctness
+- UI waits for `Clerk.isInitialized`.
+- Signed-out state renders `AuthView()`.
+- Signed-in state renders `UserButton()` or user content that includes it.
+
+4. Capability correctness
+- Social/MFA behavior aligns with runtime capability state and dashboard configuration.
+
+5. No accidental custom-flow rewrite
+- No unnecessary custom sign-in/sign-up form logic was introduced.

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clerk
-description: Clerk authentication router. Use when user asks about adding authentication, setting up Clerk, custom sign-in flows, Swift or native iOS auth, Next.js patterns, organizations, syncing users, or testing. Automatically routes to the specific skill based on their task.
+description: Clerk authentication router. Use when user asks about adding authentication, setting up Clerk, custom sign-in flows, Swift or native iOS auth, native Android auth, Next.js patterns, organizations, syncing users, or testing. Automatically routes to the specific skill based on their task.
 ---
 
 # Clerk Skills Router
@@ -45,6 +45,11 @@ Based on what you're trying to do, here's the right skill to use:
 - Native iOS Swift and SwiftUI projects
 - ClerkKit and ClerkKitUI implementation guidance
 - Source-driven patterns from `clerk-ios`
+
+**Android / native mobile auth** → Use `clerk-android`
+- Native Android Kotlin and Jetpack Compose projects
+- `clerk-android-api` and `clerk-android-ui` implementation guidance
+- Source-driven patterns from `clerk-android`
 - Do not use for Expo or React Native projects
 
 **Backend REST API** → Use `clerk-backend-api`
@@ -62,6 +67,7 @@ If you know your task, you can directly access:
 - `/clerk-webhooks` - Webhooks
 - `/clerk-testing` - Testing
 - `/clerk-swift` - Swift/native iOS
+- `/clerk-android` - Native Android
 - `/clerk-backend-api` - Backend REST API
 
 Or describe what you need and I'll recommend the right one.


### PR DESCRIPTION
Summary
- document the new clerk-android skill in README, backend command routing, and marketplace metadata
- add a full `skills/android/SKILL.md` plus prebuilt/custom reference files outlining prerequisites, flow selection, and source-driven guidance
- ensure the clerk skill router knows about native Android and excludes Expo/React Native requests

Testing
- Not run (not requested)