### PR TITLE
docs(nextjs-patterns): clarify proxy.ts vs middleware.ts by Next.js version

### DIFF
--- a/skills/nextjs-patterns/references/middleware-strategies.md
+++ b/skills/nextjs-patterns/references/middleware-strategies.md
@@ -1,5 +1,7 @@
 # Middleware Strategies (HIGH)
 
+> **Version note:** In Next.js 16+, use `proxy.ts`. If you're using Next.js <=15, name your file `middleware.ts` instead of `proxy.ts`. The code itself remains the same; only the filename changes.
+
 ## Public-First (marketing sites, blogs)
 
 Protect specific routes, allow everything else:


### PR DESCRIPTION
## Summary

While using the `skills/nextjs-patterns` skill in a Next.js 16 project, the generated file was `middleware.ts`.
For Next.js 16, the correct filename should be `proxy.ts`.

This PR adds a version note to `skills/nextjs-patterns/references/middleware-strategies.md` to clarify:

- Next.js 16+ -> use `proxy.ts`
- Next.js <=15 -> use `middleware.ts`
- Middleware code stays the same; only the filename changes.

## Why this change

Without explicit version guidance, the skill can produce the wrong filename for Next.js 16, which may cause middleware not to be applied as expected.

## Validation

I verified this locally:

1. Reproduced the issue on Next.js 16: the skill output used `middleware.ts`.
2. Added the version note in the skill reference.
3. Re-ran the flow and confirmed the generated file is now `proxy.ts` (expected behavior).

## Scope

skills/nextjs-patterns/references/middleware-strategies.md