### PR TITLE
docs: recommend shadcn theme when app uses shadcn/ui

### DIFF
--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -115,7 +115,7 @@ import { dark, neobrutalism } from '@clerk/ui/themes'
 
 #### shadcn Theme
 
-**If the project uses shadcn/ui** (check for `components.json` in the project root), **always use the shadcn theme** so Clerk components match the app's design system. See [shadcn theme docs](https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme) for details.
+**If the project uses shadcn/ui** (check for `components.json` in the project root), **always use the shadcn theme**:
 
 ```typescript
 import { shadcn } from '@clerk/ui/themes'

--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -115,7 +115,7 @@ import { dark, neobrutalism } from '@clerk/ui/themes'
 
 #### shadcn Theme
 
-If the project has `components.json` (shadcn/ui installed), use the shadcn theme:
+**If the project uses shadcn/ui** (check for `components.json` in the project root), **always use the shadcn theme** so Clerk components match the app's design system. See [shadcn theme docs](https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme) for details.
 
 ```typescript
 import { shadcn } from '@clerk/ui/themes'

--- a/skills/orgs/SKILL.md
+++ b/skills/orgs/SKILL.md
@@ -213,10 +213,6 @@ user.enterpriseAccounts
 
 > **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` instead of `strategy: 'enterprise_sso'`, and `user.samlAccounts` instead of `user.enterpriseAccounts`.
 
-## Appearance
-
-If the project uses shadcn/ui (check for `components.json`), apply the shadcn theme so Clerk organization components match the app's design system. See `custom-ui/` skill for full theming details and [shadcn theme docs](https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme).
-
 ## Common Pitfalls
 
 | Symptom | Cause | Solution |

--- a/skills/orgs/SKILL.md
+++ b/skills/orgs/SKILL.md
@@ -213,6 +213,10 @@ user.enterpriseAccounts
 
 > **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` instead of `strategy: 'enterprise_sso'`, and `user.samlAccounts` instead of `user.enterpriseAccounts`.
 
+## Appearance
+
+If the project uses shadcn/ui (check for `components.json`), apply the shadcn theme so Clerk organization components match the app's design system. See `custom-ui/` skill for full theming details and [shadcn theme docs](https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme).
+
 ## Common Pitfalls
 
 | Symptom | Cause | Solution |

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -224,8 +224,6 @@ Also import the shadcn CSS in your global styles:
 
 > **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css` instead.
 
-See [shadcn theme docs](https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme) for details.
-
 ## Common Pitfalls
 
 | Level | Issue | Solution |

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -202,6 +202,30 @@ npm install @clerk/ui
 
 > **Core 2 ONLY (skip if current SDK):** Themes are from `@clerk/themes` instead of `@clerk/ui`.
 
+### shadcn Theme
+
+If the project uses shadcn/ui (check for `components.json` in the project root), apply the shadcn theme so Clerk components match the app's design system:
+
+```bash
+npm install @clerk/ui
+```
+
+```tsx
+import { shadcn } from '@clerk/ui/themes'
+
+<ClerkProvider appearance={{ theme: shadcn }}>{children}</ClerkProvider>
+```
+
+Also import the shadcn CSS in your global styles:
+```css
+@import 'tailwindcss';
+@import '@clerk/ui/themes/shadcn.css';
+```
+
+> **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css` instead.
+
+See [shadcn theme docs](https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme) for details.
+
 ## Common Pitfalls
 
 | Level | Issue | Solution |


### PR DESCRIPTION
## Summary

- **setup/SKILL.md**: Added shadcn theme section with full setup instructions (install, provider config, CSS import) during initial Clerk setup when shadcn/ui is detected
- **custom-ui/SKILL.md**: Strengthened existing shadcn section to explicitly recommend always using the shadcn theme when shadcn/ui is present, with link to docs

Reference: https://clerk.com/docs/nextjs/guides/customizing-clerk/appearance-prop/themes#shadcn-theme

## Test plan

- [ ] Verify setup skill recommends shadcn theme when `components.json` is present
- [ ] Verify custom-ui skill strongly recommends shadcn theme for shadcn/ui projects
- [ ] Verify orgs skill mentions shadcn theme with cross-reference to custom-ui
- [ ] Confirm Core 2 callouts are included where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)