### PR TITLE
feat: update skills for v0-Clerk integration launch

### DIFF
--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -113,7 +113,9 @@ import { dark, neobrutalism } from '@clerk/ui/themes'
 
 **Available themes:** `dark`, `neobrutalism`, `shadcn`, `simple`
 
-#### shadcn Theme
+#### shadcn Theme (HIGH PRIORITY)
+
+> **IMPORTANT:** If the project has `components.json` (shadcn/ui installed), ALWAYS apply the shadcn theme as the FIRST customization step. This ensures Clerk components visually match the existing shadcn design system. Skip this only if the user explicitly requests a different theme.
 
 **If the project uses shadcn/ui** (check for `components.json` in the project root), **always use the shadcn theme**:
 

--- a/skills/custom-ui/SKILL.md
+++ b/skills/custom-ui/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Custom UI

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -25,7 +25,7 @@ For basic setup, see `setup/`.
 | Reference | Impact |
 |-----------|--------|
 | `references/server-vs-client.md` | CRITICAL - `await auth()` vs hooks |
-| `references/middleware-strategies.md` | HIGH - Public-first vs protected-first |
+| `references/middleware-strategies.md` | HIGH - Public-first vs protected-first (`proxy.ts` in Next.js 16+) |
 | `references/server-actions.md` | HIGH - Protect mutations |
 | `references/api-routes.md` | HIGH - 401 vs 403 |
 | `references/caching-auth.md` | MEDIUM - User-scoped caching |
@@ -79,7 +79,7 @@ import { Show } from '@clerk/nextjs'
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `undefined` userId in Server Component | Missing `await` | `await auth()` not `auth()` |
-| Auth not working on API routes | Missing matcher | Add `'/(api|trpc)(.*)'` to middleware |
+| Auth not working on API routes | Missing matcher | Add `'/(api|trpc)(.*)'` to `proxy.ts` (or `middleware.ts` for Next.js <=15) |
 | Cache returns wrong user's data | Missing userId in key | Include `userId` in `unstable_cache` key |
 | Mutations bypass auth | Unprotected Server Action | Check `auth()` at start of action |
 | Wrong HTTP error code | Confused 401/403 | 401 = not signed in, 403 = no permission |

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 allowed-tools: WebFetch
 metadata:
   author: clerk
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Next.js Patterns

--- a/skills/nextjs-patterns/SKILL.md
+++ b/skills/nextjs-patterns/SKILL.md
@@ -25,7 +25,7 @@ For basic setup, see `setup/`.
 | Reference | Impact |
 |-----------|--------|
 | `references/server-vs-client.md` | CRITICAL - `await auth()` vs hooks |
-| `references/middleware-strategies.md` | HIGH - Public-first vs protected-first (`proxy.ts` in Next.js 16+) |
+| `references/middleware-strategies.md` | HIGH - Public-first vs protected-first, `proxy.ts` (Next.js <=15: `middleware.ts`) |
 | `references/server-actions.md` | HIGH - Protect mutations |
 | `references/api-routes.md` | HIGH - 401 vs 403 |
 | `references/caching-auth.md` | MEDIUM - User-scoped caching |
@@ -79,7 +79,7 @@ import { Show } from '@clerk/nextjs'
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `undefined` userId in Server Component | Missing `await` | `await auth()` not `auth()` |
-| Auth not working on API routes | Missing matcher | Add `'/(api|trpc)(.*)'` to `proxy.ts` (or `middleware.ts` for Next.js <=15) |
+| Auth not working on API routes | Missing matcher | Add `'/(api|trpc)(.*)'` to `proxy.ts` (Next.js <=15: `middleware.ts`) |
 | Cache returns wrong user's data | Missing userId in key | Include `userId` in `unstable_cache` key |
 | Mutations bypass auth | Unprotected Server Action | Check `auth()` at start of action |
 | Wrong HTTP error code | Confused 401/403 | 401 = not signed in, 403 = no permission |

--- a/skills/nextjs-patterns/references/middleware-strategies.md
+++ b/skills/nextjs-patterns/references/middleware-strategies.md
@@ -1,6 +1,6 @@
 # Middleware Strategies (HIGH)
 
-> **Version note:** In Next.js 16+, use `proxy.ts`. If you're using Next.js <=15, name your file `middleware.ts` instead of `proxy.ts`. The code itself remains the same; only the filename changes.
+> **Filename:** `proxy.ts` (Next.js <=15: `middleware.ts`). The code is identical; only the filename changes.
 
 ## Public-First (marketing sites, blogs)
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -20,8 +20,10 @@ This skill sets up Clerk for authentication by following the official quickstart
 |------|--------|
 | 1. Detect framework | Check `package.json` dependencies |
 | 2. Fetch quickstart | Use WebFetch on the appropriate docs URL |
-| 3. Follow instructions | Execute the steps from the official guide |
+| 3. Follow instructions | Execute steps; Next.js uses `proxy.ts` not `middleware.ts` |
 | 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) |
+
+> If the project has `components.json` (shadcn/ui), apply the shadcn theme after setup. See `custom-ui/` → shadcn Theme.
 
 ## Framework Detection
 
@@ -55,17 +57,13 @@ User Request: "Add Clerk" / "Add authentication"
     ├─ Read package.json
     │
     ├─ Existing auth detected?
-    │   │
-    │   ├─ YES → Audit current auth → Create migration plan
-    │   │        → See "Migrating from Another Auth Provider"
-    │   │
+    │   ├─ YES → Audit → Migration plan
     │   └─ NO → Fresh install
     │
-    ├─ Identify framework from dependencies
+    ├─ Identify framework → WebFetch quickstart → Follow instructions
+    │   └─ Next.js? → Create proxy.ts (NOT middleware.ts)
     │
-    ├─ WebFetch the appropriate quickstart URL
-    │
-    └─ Follow the official instructions step-by-step
+    └─ components.json exists? → YES → Apply shadcn theme (see custom-ui/)
 ```
 
 ## Setup Process
@@ -88,9 +86,13 @@ Prompt: "Extract the complete setup instructions including all code snippets, fi
 Execute each step from the quickstart guide:
 - Install the required packages
 - Set up environment variables
-- Add the provider/middleware
+- Add the provider and proxy/middleware
 - Create sign-in/sign-up routes if needed
 - Test the integration
+
+> **Next.js:** Create `proxy.ts` (not `middleware.ts`). See `nextjs-patterns/references/middleware-strategies.md`. Core 2 uses `middleware.ts` instead.
+
+> **shadcn/ui detected** (`components.json` exists): ALWAYS apply the shadcn theme. See `custom-ui/` → shadcn Theme section.
 
 ### 4. Get API Keys
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 allowed-tools: WebFetch
 metadata:
   author: clerk
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Adding Clerk

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -20,7 +20,7 @@ This skill sets up Clerk for authentication by following the official quickstart
 |------|--------|
 | 1. Detect framework | Check `package.json` dependencies |
 | 2. Fetch quickstart | Use WebFetch on the appropriate docs URL |
-| 3. Follow instructions | Execute steps; Next.js 16+ uses `proxy.ts`, older uses `middleware.ts` |
+| 3. Follow instructions | Execute steps; create `proxy.ts` (Next.js <=15: `middleware.ts`) |
 | 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) |
 
 > If the project has `components.json` (shadcn/ui), apply the shadcn theme after setup. See `custom-ui/` → shadcn Theme.
@@ -61,7 +61,7 @@ User Request: "Add Clerk" / "Add authentication"
     │   └─ NO → Fresh install
     │
     ├─ Identify framework → WebFetch quickstart → Follow instructions
-    │   └─ Next.js? → Create proxy.ts (NOT middleware.ts)
+    │   └─ Next.js? → Create proxy.ts (Next.js <=15: middleware.ts)
     │
     └─ components.json exists? → YES → Apply shadcn theme (see custom-ui/)
 ```
@@ -90,7 +90,7 @@ Execute each step from the quickstart guide:
 - Create sign-in/sign-up routes if needed
 - Test the integration
 
-> **Next.js:** Create `proxy.ts` (not `middleware.ts`). See `nextjs-patterns/references/middleware-strategies.md`. Core 2 uses `middleware.ts` instead.
+> **Next.js:** Create `proxy.ts` (Next.js <=15: `middleware.ts`). See `nextjs-patterns/references/middleware-strategies.md`.
 
 > **shadcn/ui detected** (`components.json` exists): ALWAYS apply the shadcn theme. See `custom-ui/` → shadcn Theme section.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -20,7 +20,7 @@ This skill sets up Clerk for authentication by following the official quickstart
 |------|--------|
 | 1. Detect framework | Check `package.json` dependencies |
 | 2. Fetch quickstart | Use WebFetch on the appropriate docs URL |
-| 3. Follow instructions | Execute steps; Next.js uses `proxy.ts` not `middleware.ts` |
+| 3. Follow instructions | Execute steps; Next.js 16+ uses `proxy.ts`, older uses `middleware.ts` |
 | 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) |
 
 > If the project has `components.json` (shadcn/ui), apply the shadcn theme after setup. See `custom-ui/` → shadcn Theme.


### PR DESCRIPTION
## Summary

Builds on #20 (shadcn theme recommendation). Adds:

- **proxy.ts**: Skills now reference `proxy.ts` (Next.js <=15: `middleware.ts`) with standardized phrasing across all files
- **Decision tree**: Updated setup flow to guide agents through proxy.ts and shadcn detection
- **Version bumps**: setup, custom-ui, nextjs-patterns bumped to v2.1.0
- **HIGH PRIORITY callout**: shadcn theme section in custom-ui marked as mandatory when `components.json` exists

## Files changed

- `setup/SKILL.md` - proxy.ts callout, decision tree, version bump
- `custom-ui/SKILL.md` - HIGH PRIORITY label + IMPORTANT callout, version bump
- `nextjs-patterns/SKILL.md` - proxy.ts references in table and pitfalls, version bump
- `nextjs-patterns/references/middleware-strategies.md` - standardized filename note

## Verified

- Scaffolded Next.js 16 + shadcn/ui test project
- Following the skill produces `proxy.ts` (not `middleware.ts`)
- shadcn theme applied via `@clerk/ui/themes`
- `bun run build` passes, Next.js shows `f Proxy (Middleware)`