### PR TITLE
docs(readme): remove Clerk CLI install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ Skills follow the [Agent Skills](https://agentskills.io/) format.
 npx skills add clerk/skills
 ```
 
-### Via Clerk CLI
-
-```bash
-clerk init  # auto-installs skills for your framework
-```
-
 ### Manual (Claude Code)
 
 ```bash


### PR DESCRIPTION
Removes the `clerk init` install option from README -- Clerk CLI isn't ready yet, so we shouldn't reference it.