### PR TITLE
feat(clerk-cli): add Clerk CLI skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,14 +11,15 @@
   "plugins": [
     {
       "name": "core",
-      "description": "Core Clerk skills: router, setup, custom UI, and API references",
+      "description": "Core Clerk skills: router, setup, custom UI, API references, and CLI",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/core/clerk",
         "./skills/core/clerk-setup",
         "./skills/core/clerk-custom-ui",
-        "./skills/core/clerk-backend-api"
+        "./skills/core/clerk-backend-api",
+        "./skills/core/clerk-cli"
       ]
     },
     {

--- a/skills/core/clerk-cli/SKILL.md
+++ b/skills/core/clerk-cli/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: clerk-cli
+description: >
+  Operate the Clerk platform from the terminal. Use when the user wants to run
+  "clerk init", "clerk env pull", "clerk auth", "clerk api", "clerk doctor",
+  "clerk config", "clerk apps", or any Clerk CLI command. Covers installation,
+  agent-mode flags, and all command groups.
+license: MIT
+allowed-tools: Bash, Read, Grep, Skill
+metadata:
+  author: clerk
+  version: 1.0.0
+---
+
+# Clerk CLI
+
+> **Package**: `clerk` (npm/bun). Run `clerk --version` to check.
+
+```bash
+npm install -g clerk    # or: bun add -g clerk
+```
+
+## Agent Protocol
+
+**Always pass `--mode agent`** — suppresses prompts, spinners, and color; returns structured output; fails fast.
+
+**Pass `--yes`** on destructive commands: `unlink`, `config patch`, `config put`, mutating `api` calls, `update`.
+
+## Command Overview
+
+| Command | Description | Reference |
+|---------|-------------|-----------|
+| `clerk init` | Initialize Clerk in a project | [setup-commands.md](references/setup-commands.md) |
+| `clerk auth login\|logout` | Authenticate via browser OAuth | [setup-commands.md](references/setup-commands.md) |
+| `clerk link` | Link project to a Clerk app | [setup-commands.md](references/setup-commands.md) |
+| `clerk unlink` | Remove project-to-app association | [setup-commands.md](references/setup-commands.md) |
+| `clerk env pull` | Pull env vars to `.env.local` | [setup-commands.md](references/setup-commands.md) |
+| `clerk apps list` | List Clerk applications | [management-commands.md](references/management-commands.md) |
+| `clerk apps create` | Create a new Clerk application | [management-commands.md](references/management-commands.md) |
+| `clerk config pull\|schema\|patch\|put` | Read or modify instance config | [management-commands.md](references/management-commands.md) |
+| `clerk api` | Make authenticated API requests | [api-command.md](references/api-command.md) |
+| `clerk doctor` | Check project integration health | [diagnostics.md](references/diagnostics.md) |
+| `clerk whoami` | Show current authenticated user | [diagnostics.md](references/diagnostics.md) |
+| `clerk open` | Open Clerk resources in browser | [diagnostics.md](references/diagnostics.md) |
+| `clerk update` | Update the CLI | [diagnostics.md](references/diagnostics.md) |
+| `clerk completion` | Generate shell autocompletion | [diagnostics.md](references/diagnostics.md) |
+
+## Quick Start
+
+```bash
+clerk whoami --mode agent                        # 1. Verify auth
+clerk init --mode agent --yes --no-skills        # 2. Init (auto-detects framework)
+clerk env pull --mode agent                      # 3. Pull env vars
+clerk doctor --json --mode agent                 # 4. Health check
+```
+
+For starter templates and headless CI patterns, see [setup-commands.md](references/setup-commands.md).
+
+## Common Pitfalls
+
+- **`config put` vs `config patch`**: `put` replaces the entire config — omitted keys revert to defaults. Use `patch` for partial updates.
+- **`clerk link` in agent mode**: Always pass `--app <id>` — the interactive picker requires a TTY.
+- **`clerk api ls`**: Reads a cached endpoint catalog, not the live API. Fetches the OpenAPI spec on first run or cache expiry.
+- **Default instance is `dev`**: Pass `--instance prod` explicitly for production.
+
+## When to Load References
+
+- **Setup, auth, linking, env vars** → [setup-commands.md](references/setup-commands.md)
+- **Apps, instance config** → [management-commands.md](references/management-commands.md)
+- **Direct API calls** → [api-command.md](references/api-command.md)
+- **Doctor, whoami, open, update** → [diagnostics.md](references/diagnostics.md)
+
+## See Also
+
+- `clerk-setup` - SDK-level installation patterns (manual alternative to `clerk init`)
+- `clerk-backend-api` - Clerk Backend API schemas and endpoint reference (complement to `clerk api`)

--- a/skills/core/clerk-cli/references/api-command.md
+++ b/skills/core/clerk-cli/references/api-command.md
@@ -1,0 +1,157 @@
+# API Command
+
+Make authenticated HTTP requests to Clerk's Backend API (default) or Platform API.
+
+## Overview
+
+`clerk api` provides direct access to Clerk's REST APIs from the terminal. It automatically resolves credentials from the linked project or auth session, handles authentication headers, and supports both read and write operations.
+
+## Endpoint Discovery
+
+### clerk api ls
+
+List available API endpoints. This reads a locally cached endpoint catalog — it does **not** call Clerk's data APIs. On first run or cache expiry, it fetches the OpenAPI spec to refresh the cache.
+
+```bash
+# List all available endpoints
+clerk api ls --mode agent
+
+# Filter to endpoints matching a keyword
+clerk api ls users --mode agent
+clerk api ls organizations --mode agent
+clerk api ls sessions --mode agent
+```
+
+Use `api ls` before making calls to discover the correct endpoint path and supported methods.
+
+## Making API Calls
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `[endpoint]` | string | API path (e.g., `/users`). Omit for interactive mode (human only). |
+| `[filter]` | string | Filter keyword (used with `ls`). |
+| `-X, --method <method>` | string | HTTP method. Default: `GET`, or `POST` if a body is provided. |
+| `-d, --data <json>` | string | Inline JSON request body. |
+| `--file <path>` | string | Read request body from a file. |
+| `--include` | boolean | Show response headers alongside body. |
+| `--app <id>` | string | Application ID for key resolution. |
+| `--secret-key <key>` | string | Override the secret key directly. |
+| `--instance <id>` | string | Instance to target: `dev`, `prod`, or instance ID. **Default: `dev`.** |
+| `--platform` | boolean | Use Platform API instead of Backend API. |
+| `--dry-run` | boolean | Print the request without executing it. |
+| `--yes` | boolean | Skip confirmation for mutating requests (POST, PUT, PATCH, DELETE). |
+
+### Auth resolution
+
+Credentials are resolved in this order:
+
+1. `--secret-key` flag (highest priority)
+2. `CLERK_SECRET_KEY` environment variable
+3. Linked app credentials (from `clerk link`)
+
+When `--platform` is set, the CLI uses a separate auth path: `CLERK_PLATFORM_API_KEY` env var or the OAuth token from `clerk auth login`.
+
+### Instance targeting
+
+Default is `dev`. **Always pass `--instance prod` when targeting production** to avoid accidentally reading or modifying development data.
+
+## Examples
+
+### Read operations (GET)
+
+```bash
+# List users
+clerk api /users --mode agent
+
+# List users in production
+clerk api /users --instance prod --mode agent
+
+# Get a specific user
+clerk api /users/user_abc123 --mode agent
+
+# List organizations
+clerk api /organizations --mode agent
+
+# Show response headers
+clerk api /users --include --mode agent
+```
+
+### Write operations
+
+```bash
+# Create a user (POST inferred from --data)
+clerk api /users -d '{"email_address":["user@example.com"],"password":"S3cure!Pass"}' --yes --mode agent
+
+# Update a user (explicit PUT)
+clerk api /users/user_abc123 -X PUT -d '{"first_name":"Alice"}' --yes --mode agent
+
+# Delete a user
+clerk api /users/user_abc123 -X DELETE --yes --mode agent
+
+# Request body from file
+clerk api /users --file new-user.json --yes --mode agent
+```
+
+### Dry run
+
+Preview the request without executing it. Outputs a curl-equivalent command.
+
+```bash
+clerk api /users -d '{"email_address":["user@example.com"]}' --dry-run --mode agent
+```
+
+### Platform API
+
+Access organization-level resources using the Platform API instead of the Backend API.
+
+```bash
+clerk api /organizations --platform --mode agent
+```
+
+### Explicit secret key
+
+Bypass the auth resolution chain with a direct key.
+
+```bash
+clerk api /users --secret-key sk_test_xxx --mode agent
+```
+
+## Common API Paths
+
+| Resource | Endpoint | Methods |
+|----------|----------|---------|
+| Users | `/users` | GET, POST |
+| User by ID | `/users/<user_id>` | GET, PUT, DELETE |
+| Sessions | `/sessions` | GET |
+| Session by ID | `/sessions/<session_id>` | GET, POST (revoke) |
+| Organizations | `/organizations` | GET, POST |
+| Organization by ID | `/organizations/<org_id>` | GET, PUT, DELETE |
+| Organization members | `/organizations/<org_id>/memberships` | GET, POST |
+| Invitations | `/invitations` | GET, POST |
+| Invitation by ID | `/invitations/<invitation_id>` | GET, POST (revoke) |
+| Allowlist | `/allowlist_identifiers` | GET, POST |
+| Blocklist | `/blocklist_identifiers` | GET, POST |
+
+Use `clerk api ls <keyword> --mode agent` to discover additional endpoints.
+
+## Pagination
+
+GET endpoints that return lists are paginated. Pass `limit` and `offset` as query parameters:
+
+```bash
+# First 10 users
+clerk api '/users?limit=10' --mode agent
+
+# Next page (skip first 10)
+clerk api '/users?limit=10&offset=10' --mode agent
+```
+
+Check the response for `total_count` to determine if more pages exist. Use `clerk api ls <resource> --mode agent` to discover the full parameter set for an endpoint.
+
+## Notes
+
+- Response is always JSON
+- `--dry-run` outputs a curl-equivalent without executing
+- Mutating requests (POST, PUT, PATCH, DELETE) prompt for confirmation unless `--yes` is passed

--- a/skills/core/clerk-cli/references/diagnostics.md
+++ b/skills/core/clerk-cli/references/diagnostics.md
@@ -1,0 +1,188 @@
+# Diagnostics & Utility Commands
+
+Commands for checking integration health, verifying authentication, and managing the CLI itself.
+
+## clerk doctor
+
+Run health checks on the current project's Clerk integration. Validates CLI version, auth status, linked app, environment variables, SDK version, and middleware configuration.
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--verbose` | boolean | Show detailed output for each check. |
+| `--json` | boolean | Output results as JSON. |
+| `--spotlight` | boolean | Only show warnings and failures (suppress passing checks). |
+| `--fix` | boolean | Attempt to auto-fix detected issues. |
+
+### What it checks
+
+- CLI version — is it up to date?
+- Auth status — is the user logged in? Is the token valid?
+- Linked app — is the project linked? Is the application reachable? Are instance IDs current?
+- Environment variables — are `CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` present and correctly formatted?
+- CLI configuration — is the config file valid?
+- Shell completion — is autocompletion installed?
+
+### Exit codes
+
+- `0` — all checks pass (or only warnings)
+- `1` — at least one check failed
+
+### `--fix` scope
+
+Auto-fix runs one of three repair actions depending on the failing check:
+
+| Fix action | Triggered by |
+|------------|-------------|
+| Re-run `clerk auth login` | Not logged in, invalid/expired token, missing CLI config |
+| Re-run `clerk link` | Project not linked, app unreachable (404), stale instance IDs |
+| Re-run `clerk env pull` | Missing environment variables |
+
+It cannot fix CLI version warnings, shell completion issues, or problems requiring code changes (e.g., middleware misconfiguration). Use `--spotlight` first to review failures before applying `--fix`.
+
+### Agent-mode examples
+
+```bash
+# Machine-readable health check
+clerk doctor --json --mode agent
+
+# Only show problems
+clerk doctor --spotlight --mode agent
+
+# Auto-fix issues and report results
+clerk doctor --fix --json --mode agent
+
+# Detailed output for debugging
+clerk doctor --verbose --mode agent
+```
+
+### JSON output shape
+
+```json
+{
+  "checks": [
+    {
+      "name": "clerk-version",
+      "status": "pass",
+      "message": "Clerk CLI is up to date"
+    },
+    {
+      "name": "env-vars",
+      "status": "fail",
+      "message": "CLERK_SECRET_KEY is missing from .env.local"
+    }
+  ],
+  "overall": "fail"
+}
+```
+
+Each check has a `status` of `pass`, `warn`, or `fail`. The `overall` field reflects the worst status across all checks.
+
+### Using doctor in CI
+
+```bash
+# Fail the pipeline if any check fails
+clerk doctor --json --mode agent
+# Exit code 1 triggers CI failure automatically
+```
+
+---
+
+## clerk whoami
+
+Show the email address of the currently authenticated Clerk account.
+
+```bash
+clerk whoami --mode agent
+```
+
+No additional flags beyond global options. Output is plain text (the email address). Returns exit code `1` if not authenticated.
+
+Use this to verify auth status before running other commands:
+
+```bash
+clerk whoami --mode agent && clerk env pull --mode agent
+```
+
+---
+
+## clerk open
+
+Open Clerk resources in the default browser. Currently, `dashboard` is the only subcommand. Run `clerk open --help --mode agent` to check for additional subcommands in your CLI version.
+
+### clerk open dashboard
+
+Open the linked application's dashboard, optionally navigating to a specific subpath.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `[subpath]` | string | Optional dashboard page: `users`, `api-keys`, `settings`, etc. |
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--print` | boolean | Print the URL without opening the browser. |
+
+```bash
+# Open the dashboard (human mode)
+clerk open dashboard
+
+# Print the URL only (agent-safe — no browser launch)
+clerk open dashboard --print --mode agent
+
+# Open a specific dashboard page
+clerk open dashboard users --print --mode agent
+clerk open dashboard api-keys --print --mode agent
+clerk open dashboard settings --print --mode agent
+```
+
+> **Agent note:** Always use `--print` in agent mode. Without it, the command attempts to open a browser, which fails in headless environments and may hang indefinitely.
+
+---
+
+## clerk update
+
+Update the CLI binary to the latest version.
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--channel <tag>` | string | npm dist-tag to update to. Common values: `latest` (default), `canary`. Any valid dist-tag is accepted. |
+| `-y, --yes` | boolean | Skip confirmation prompt. |
+
+```bash
+# Update to latest stable
+clerk update --yes --mode agent
+
+# Update to canary
+clerk update --channel canary --yes --mode agent
+```
+
+> Always pass `--yes` in agent mode to skip the confirmation prompt.
+
+---
+
+## clerk completion
+
+Generate shell autocompletion scripts. This is a developer workstation setup command — not typically used by agents.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `[shell]` | string | Shell type. Choices: `bash`, `zsh`, `fish`, `powershell`. |
+
+### Installation by shell
+
+| Shell | One-time setup |
+|-------|----------------|
+| **Bash** | `clerk completion bash > /etc/bash_completion.d/clerk` |
+| **Zsh** | `mkdir -p ~/.zfunc && clerk completion zsh > ~/.zfunc/_clerk`, then add to `~/.zshrc`: `fpath=(~/.zfunc $fpath); autoload -Uz compinit && compinit` |
+| **Fish** | `clerk completion fish > ~/.config/fish/completions/clerk.fish` |
+| **PowerShell** | `clerk completion powershell >> $PROFILE` |
+
+For temporary use in the current session:
+
+```bash
+eval "$(clerk completion bash)"   # Bash
+eval "$(clerk completion zsh)"    # Zsh
+```

--- a/skills/core/clerk-cli/references/management-commands.md
+++ b/skills/core/clerk-cli/references/management-commands.md
@@ -1,0 +1,223 @@
+# Management Commands
+
+Commands for managing Clerk applications and instance configuration.
+
+## clerk apps
+
+Manage Clerk applications from the terminal.
+
+### clerk apps list
+
+List all Clerk applications associated with the authenticated account.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` | boolean | Output as JSON. |
+
+```bash
+# Human-readable table
+clerk apps list --mode agent
+
+# Machine-readable JSON
+clerk apps list --json --mode agent
+```
+
+JSON output shape (top-level array):
+
+```json
+[
+  {
+    "application_id": "app_abc123",
+    "name": "My App",
+    "instances": [...]
+  }
+]
+```
+
+Use the `application_id` field from this output with `--app` flags on other commands. An empty account returns `[]`.
+
+### clerk apps create
+
+Create a new Clerk application.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<name>` | string | Yes | Application name (positional argument). |
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` | boolean | Output as JSON. |
+
+```bash
+# Create an app
+clerk apps create "My SaaS App" --mode agent
+
+# Create and capture the ID
+clerk apps create "My SaaS App" --json --mode agent
+```
+
+> **Agent note:** `clerk apps create` does not prompt for confirmation. Always use `--json` in agent mode to capture the new app ID programmatically.
+
+JSON output shape:
+
+```json
+{
+  "application_id": "app_xyz789",
+  "name": "My SaaS App"
+}
+```
+
+---
+
+## clerk config
+
+Read and modify instance configuration. An "instance" is a Clerk environment (development or production) within an application.
+
+Config values are JSON objects organized by key (e.g., `social_login`, `password_settings`, `session_settings`). Use `config schema` to discover available keys and their shapes.
+
+### Shared flags (all config subcommands)
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--app <id>` | string | Application ID to target. Works from any directory. |
+| `--instance <id>` | string | Instance to target: `dev`, `prod`, or a full instance ID. **Default: `dev`.** |
+
+> **Note:** Config commands do **not** accept `--secret-key`. They authenticate via the Platform API using your OAuth session (from `clerk auth login`) or `CLERK_PLATFORM_API_KEY` env var.
+
+### clerk config pull
+
+Read the current instance configuration.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--output <file>` | string | Write config to a file instead of stdout. |
+| `--keys <keys...>` | string[] | Retrieve only specific config keys. |
+
+```bash
+# Print entire dev config to stdout
+clerk config pull --mode agent
+
+# Pull production config to a file
+clerk config pull --instance prod --output prod-config.json --mode agent
+
+# Pull a single config key
+clerk config pull --keys social_login --mode agent
+
+# Pull multiple specific keys
+clerk config pull --keys social_login password_settings --mode agent
+```
+
+Use `config pull` to snapshot configuration before making changes. This enables safe rollback if a patch or put goes wrong.
+
+### clerk config schema
+
+Retrieve the JSON schema describing available config keys and their allowed values.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--output <file>` | string | Write schema to a file instead of stdout. |
+| `--keys <keys...>` | string[] | Schema for specific config keys only. |
+
+```bash
+# Full schema — discover all available config keys
+clerk config schema --mode agent
+
+# Schema for a specific key — understand its shape before patching
+clerk config schema --keys social_login --mode agent
+
+# Save to file for reference
+clerk config schema --output schema.json --mode agent
+```
+
+**Always run `config schema` before patching** to understand the expected shape and allowed values for config keys.
+
+### clerk config patch (PARTIAL UPDATE)
+
+Merge changes into the existing instance configuration. Only the keys provided in the payload are modified — all other keys remain unchanged.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--file <path>` | string | Read config JSON from a file. One of `--file` or `--json` required. |
+| `--json <string>` | string | Pass config JSON inline. One of `--file` or `--json` required. |
+| `--dry-run` | boolean | Preview the change without applying it. |
+| `--yes` | boolean | Skip confirmation prompt. |
+| `--destructive` | boolean | Allow destructive changes that delete resources (e.g., session templates, custom OAuth providers). |
+
+```bash
+# Inline JSON patch
+clerk config patch --json '{"social_login":{"enabled":true}}' --yes --mode agent
+
+# Patch from file
+clerk config patch --file config-changes.json --yes --mode agent
+
+# Preview before applying
+clerk config patch --file config-changes.json --dry-run --mode agent
+
+# Patch production
+clerk config patch --instance prod --file config-changes.json --yes --mode agent
+
+# Allow destructive changes
+clerk config patch --file config-changes.json --yes --destructive --mode agent
+```
+
+> **`patch` vs `put`:** `patch` merges with existing config. Keys not in the payload are untouched. **Prefer `patch` over `put` for targeted changes.**
+
+> **`--destructive` flag:** Required when the patch would delete resources (custom OAuth providers, session templates). Without this flag, the operation resets affected resources to defaults instead of deleting them. When in doubt, use `--dry-run` first.
+
+### clerk config put (FULL REPLACE)
+
+Replace the **entire** instance configuration. Any config keys not included in the payload revert to their default values.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--file <path>` | string | Read config JSON from a file. One of `--file` or `--json` required. |
+| `--json <string>` | string | Pass config JSON inline. One of `--file` or `--json` required. |
+| `--dry-run` | boolean | Preview the replacement without applying it. |
+| `--yes` | boolean | Skip confirmation prompt. |
+| `--destructive` | boolean | Allow destructive changes that delete resources. |
+
+> **CAUTION:** `put` replaces the entire config. Omitted keys revert to defaults. Always pull the current config first, edit it, then put it back.
+
+### Safe `put` workflow
+
+```bash
+# 1. Snapshot current config
+clerk config pull --output current.json --mode agent
+
+# 2. Edit current.json (make your changes)
+
+# 3. Preview the replacement
+clerk config put --file current.json --dry-run --mode agent
+
+# 4. Apply (only after reviewing the dry-run output)
+clerk config put --file current.json --yes --mode agent
+```
+
+### Production config workflow
+
+```bash
+# 1. Pull production config
+clerk config pull --instance prod --output prod.json --mode agent
+
+# 2. Edit prod.json
+
+# 3. Preview
+clerk config patch --instance prod --file prod.json --dry-run --mode agent
+
+# 4. Apply
+clerk config patch --instance prod --file prod.json --yes --mode agent
+```
+
+### Common config keys
+
+Use `clerk config schema --mode agent` for the full list. Common keys include:
+
+| Key | Description |
+|-----|-------------|
+| `social_login` | Social provider configuration (Google, GitHub, etc.) |
+| `password_settings` | Password policies and requirements |
+| `session_settings` | Session lifetime, token configuration |
+| `sign_up_settings` | Sign-up form configuration |
+| `sign_in_settings` | Sign-in methods and strategies |
+| `email_settings` | Email verification, templates |
+| `organization_settings` | Organization features and permissions |

--- a/skills/core/clerk-cli/references/setup-commands.md
+++ b/skills/core/clerk-cli/references/setup-commands.md
@@ -1,0 +1,221 @@
+# Setup Commands
+
+Commands for authenticating, initializing projects, linking apps, and pulling environment variables.
+
+## clerk auth
+
+Manage authentication with the Clerk platform. Required before using most other commands.
+
+### clerk auth login
+
+Opens a browser for OAuth authentication. Stores credentials locally after successful login.
+
+Aliases: `signup`, `signin`, `sign-in` — all equivalent to `login`.
+
+```bash
+clerk auth login --mode agent
+```
+
+No additional flags beyond global options.
+
+> **Agent note:** This command is intentionally interactive — it launches a browser for OAuth. There is no `--key` or `--token` flag for headless auth.
+>
+> **For headless CI/CD:** Skip `clerk auth login` entirely. Instead set `CLERK_SECRET_KEY` env var or pass `--secret-key <key>` to commands that support it (e.g., `clerk api`).
+
+> **Shortcut:** `clerk login` is a top-level alias that bypasses the `auth` subgroup.
+
+### Auth resolution order
+
+Commands that need a secret key resolve credentials in this order:
+
+1. `--secret-key` flag (highest priority)
+2. `CLERK_SECRET_KEY` environment variable
+3. Linked app credentials (from `clerk link`)
+
+Config commands (`config pull/schema/patch/put`) use the Platform API instead — they authenticate via OAuth session or `CLERK_PLATFORM_API_KEY` env var.
+
+### clerk auth logout
+
+Remove stored credentials from the local machine.
+
+Aliases: `signout`, `sign-out` — all equivalent to `logout`.
+
+```bash
+clerk auth logout --mode agent
+```
+
+No additional flags beyond global options.
+
+> **Shortcut:** `clerk logout` is a top-level alias that bypasses the `auth` subgroup.
+
+---
+
+## clerk init
+
+Initialize Clerk in a project. Installs the appropriate SDK package, creates/updates environment files, and adds configuration stubs (middleware, providers).
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--framework <name>` | string | Framework to set up. Choices: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `javascript`, `express`, `fastify`. Skips auto-detection when provided. |
+| `--pm <manager>` | string | Package manager. Choices: `bun`, `pnpm`, `yarn`, `npm`. Skips prompt/auto-detection. |
+| `--name <project-name>` | string | Project name (used with `--starter` only, skips prompt). |
+| `--starter` | boolean | Create a new project from a starter template instead of initializing in an existing project. |
+| `--prompt` | boolean | Output a setup prompt for an AI agent instead of running setup. Does not modify any files. |
+| `--no-skills` | boolean | Skip the optional agent skills install prompt. |
+| `--app <id>` | string | Link to a specific Clerk application during init. |
+| `-y, --yes` | boolean | Skip all confirmation prompts. |
+
+### What it does
+
+1. Auto-detects the framework from `package.json` (unless `--framework` is provided)
+2. Installs the appropriate SDK package (e.g., `@clerk/nextjs` for Next.js)
+3. Creates or updates `.env.local` with placeholder Clerk keys
+4. Adds `ClerkProvider` wrapper and middleware stubs where applicable
+5. Optionally prompts to install Clerk agent skills (skip with `--no-skills`)
+
+If Clerk is already initialized (SDK installed, files scaffolded), the command prints "Clerk is already set up in this project." and exits without modifying files.
+
+### Agent-mode examples
+
+```bash
+# Existing project — auto-detect framework
+clerk init --mode agent -y
+
+# Explicit framework and package manager
+clerk init --framework next --pm bun --mode agent -y
+
+# New project from starter template
+clerk init --starter --framework next --pm bun --name "my-saas" --mode agent -y
+
+# Link to specific app during init
+clerk init --app app_abc123 --mode agent -y
+
+# Skip agent skills prompt
+clerk init --mode agent -y --no-skills
+```
+
+### The `--prompt` flag
+
+Outputs a short instruction telling an agent to run `clerk init -y`. Does not install anything or modify files.
+
+```bash
+clerk init --prompt
+```
+
+Use this to pass a setup hint to another agent session.
+
+### Starter templates
+
+```bash
+clerk init --starter --framework next --pm bun --mode agent --yes
+```
+
+### Headless CI (no browser auth)
+
+```bash
+export CLERK_SECRET_KEY=sk_test_xxx
+clerk api /users --secret-key $CLERK_SECRET_KEY --mode agent
+```
+
+---
+
+## clerk link
+
+Associate the current project directory with a Clerk application. Other commands (like `clerk env pull`) use this association to resolve which app to target.
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--app <id>` | string | Application ID to link directly (skips interactive picker). |
+
+### What it does
+
+Writes the linked application ID to the project's local configuration. Subsequent commands automatically target this app without needing `--app` on every call.
+
+### Agent-mode examples
+
+```bash
+# Link to a specific app (required in agent mode)
+clerk link --app app_abc123 --mode agent
+```
+
+> **Agent note:** Without `--app`, the command launches an interactive picker that requires a TTY. **Always pass `--app <id>` in agent mode** — omitting it will cause the command to fail in non-interactive environments.
+
+### Finding your app ID
+
+```bash
+# List apps to find the ID
+clerk apps list --json --mode agent
+```
+
+The output includes `application_id` fields like `app_abc123` that can be passed to `--app`.
+
+---
+
+## clerk unlink
+
+Remove the project-to-app association created by `clerk link`.
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--yes` | boolean | Skip confirmation prompt. |
+
+### Agent-mode example
+
+```bash
+clerk unlink --yes --mode agent
+```
+
+> Always pass `--yes` in agent mode — the confirmation prompt requires interactive input.
+
+---
+
+## clerk env pull
+
+Pull environment variables (publishable key, secret key, and framework-specific variables) from Clerk and write them to an env file.
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--app <id>` | string | Application ID to target. Works from any directory (does not require `clerk link`). |
+| `--instance <id>` | string | Instance to target: `dev`, `prod`, or a full instance ID. Default: `dev`. |
+| `--file <path>` | string | Target env file. Default: auto-detect (usually `.env.local`). |
+
+### What it writes
+
+Depending on the framework, the output file will contain:
+
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` / `CLERK_PUBLISHABLE_KEY` (or framework equivalent)
+- `CLERK_SECRET_KEY`
+- Any additional framework-specific variables
+
+### Agent-mode examples
+
+```bash
+# Pull dev keys to .env.local (default)
+clerk env pull --mode agent
+
+# Pull production keys
+clerk env pull --instance prod --mode agent
+
+# Write to a custom file
+clerk env pull --file .env --mode agent
+
+# Pull from a specific app (no clerk link required)
+clerk env pull --app app_abc123 --mode agent
+
+# Pull production keys from a specific app to a custom file
+clerk env pull --app app_abc123 --instance prod --file .env.production --mode agent
+```
+
+### Important notes
+
+- This command does **not** accept `--secret-key`. It resolves credentials via the Clerk OAuth session (from `clerk auth login`) or a linked app (`--app`). There is no mechanism to derive publishable keys from a secret key alone.
+- For CI without a linked project, use `clerk env pull --app <id>` after authenticating with `clerk auth login`, or set `CLERK_SECRET_KEY` directly in your CI environment.
+- If the target file already exists, existing Clerk keys are updated in place. Non-Clerk variables in the file are preserved.

--- a/skills/core/clerk/SKILL.md
+++ b/skills/core/clerk/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: clerk
 description: Clerk authentication router. Use when user asks about adding authentication,
-  setting up Clerk, custom sign-in flows, Swift or native iOS auth, native Android
-  auth, Next.js patterns, React patterns, Vue patterns, Nuxt patterns, Astro patterns,
-  TanStack Start patterns, Expo patterns, React Router patterns, Chrome Extension patterns,
-  organizations, syncing users, or testing. Automatically routes to the specific skill
-  based on their task.
+  setting up Clerk, custom sign-in flows, CLI commands, "clerk init", "clerk env pull",
+  "clerk api", "clerk doctor", Swift or native iOS auth, native Android auth, Next.js
+  patterns, React patterns, Vue patterns, Nuxt patterns, Astro patterns, TanStack Start
+  patterns, Expo patterns, React Router patterns, Chrome Extension patterns, organizations,
+  syncing users, or testing. Automatically routes to the specific skill based on their task.
 license: MIT
 metadata:
   version: 2.0.0
@@ -121,6 +121,12 @@ All skills are written for the current SDK. When something differs in Core 2, it
 - Inspect endpoint schemas
 - Execute API requests with scope enforcement
 
+**Clerk CLI (terminal commands)** → Use `clerk-cli`
+- `clerk init`, `clerk auth`, `clerk link`, `clerk env pull`
+- `clerk apps`, `clerk config` management
+- `clerk api` authenticated HTTP requests
+- `clerk doctor`, `clerk whoami`, `clerk open`
+
 ## Quick Navigation
 
 If you know your task, you can directly access:
@@ -141,5 +147,6 @@ If you know your task, you can directly access:
 - `/clerk-swift` - Swift/native iOS
 - `/clerk-android` - Native Android
 - `/clerk-backend-api` - Backend REST API
+- `/clerk-cli` - CLI commands (init, auth, link, env, apps, config, api, doctor)
 
 Or describe what you need and I'll recommend the right one.


### PR DESCRIPTION
## Summary

- Add new `clerk-cli` skill covering all 14 commands of the Clerk CLI with agent-first patterns
- SKILL.md (477 words) with agent protocol, command overview table, quick start, and common pitfalls
- 4 reference files grouped by workflow: setup, management, API, diagnostics
- Source-verified against `clerk/cli-new` for accuracy (auth resolution order, JSON output shapes, doctor fix scope, command aliases)
- Register `clerk-cli` in the core plugin group in `marketplace.json`
- Add CLI routing to the `clerk` router skill (trigger phrases + By Task + Quick Navigation)

## What's covered

| Reference | Commands |
|-----------|----------|
| setup-commands.md | `auth login/logout`, `init`, `link`, `unlink`, `env pull` |
| management-commands.md | `apps list/create`, `config pull/schema/patch/put` |
| api-command.md | `api ls`, `api [endpoint]`, pagination |
| diagnostics.md | `doctor`, `whoami`, `open`, `update`, `completion` |

## Key design decisions

- **Agent Protocol in SKILL.md** so `--mode agent` contract is always loaded
- **Grouped references** (4 files, not 14) for efficient context loading
- **Optimized for token efficiency** — SKILL.md is a routing table, not a manual (477 words, under 500-word guideline)
- **Source-verified** against cli-new repo: correct auth resolution order, correct JSON shapes, correct doctor fix scope, all command aliases documented

## Test plan

- [x] Symlink `clerk-cli` into `~/.claude/skills/` and start a new Claude Code session
- [x] Ask "how do I pull my Clerk env vars from the CLI?" — skill should activate
- [x] Ask "how do I make an API call with clerk" — should route to api-command.md reference
- [x] Verify `clerk` router skill correctly dispatches CLI queries to `clerk-cli`
- [x] Run `claude --debug` to confirm skill loads without YAML errors