### PR TITLE
refactor(orgs): accuracy + progressive disclosure pass

### DIFF
--- a/skills/features/clerk-orgs/SKILL.md
+++ b/skills/features/clerk-orgs/SKILL.md
@@ -5,94 +5,105 @@ description: Clerk Organizations for B2B SaaS - create multi-tenant apps with or
   workspaces, RBAC, org-based routing, member management.
 allowed-tools: WebFetch
 license: MIT
+compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY. Organizations must be enabled in Clerk Dashboard → Organizations. Membership mode (required vs optional) must match the B2B vs B2C + B2B coexistence story of your app.
 metadata:
   author: clerk
-  version: 2.1.0
-  inputs:
-  - name: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-    description: Clerk publishable key from dashboard
-    required: true
-  - name: CLERK_SECRET_KEY
-    description: Clerk secret key for server-side operations
-    required: true
+  version: 3.0.0
 ---
 
 # Organizations (B2B SaaS)
 
-> **Prerequisite**: Enable Organizations in Clerk Dashboard first.
+> **STOP — Dashboard-only prerequisite.** Organizations must be enabled in the Clerk Dashboard before any org-related API, hook, or component works. Open [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) and enable Organizations. Also decide `Membership required` (B2B-only, the default since Aug 22, 2025) vs `Membership optional` (B2C + B2B coexistence). Pick wrong and `<PricingTable />`, `<OrganizationSwitcher />`, and personal-account flows break silently.
 >
-> **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts.
+> **Version**: This skill targets current SDKs (`@clerk/nextjs` v7+, `@clerk/react` v6+ — Core 3). Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts — see `clerk` skill for the full version table.
 
 ## Quick Start
 
-1. **Create an organization via dashboard** or through Clerk API
-2. **Use OrganizationSwitcher** to let users switch between orgs
-3. **Protect routes** using orgSlug from URL and role checks
+1. **Enable Organizations** — [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings). Pick `Membership required` (B2B-only) or `Membership optional` (B2C + B2B). Dashboard-only; no CLI path.
+2. **Create an org** — via `<OrganizationSwitcher />`, `<CreateOrganization />`, or programmatically with `clerkClient().organizations.createOrganization()`.
+3. **Protect routes** — read `orgId` / `orgSlug` from `auth()` and gate with `has({ role })` or `has({ permission })`.
+4. **Manage members** — send invitations via Backend API or the built-in `<OrganizationProfile />` tab.
+5. **Cap membership** — set `maxAllowedMemberships` at org creation or pick a seat-limited Billing Plan (see `clerk-billing` skill).
 
-## Documentation Reference
+## What Do You Need?
 
-| Task | Link |
-|------|------|
-| Overview | https://clerk.com/docs/guides/organizations/overview |
-| Org slugs in URLs | https://clerk.com/docs/guides/organizations/org-slugs-in-urls |
-| Roles & permissions | https://clerk.com/docs/guides/organizations/control-access/roles-and-permissions |
-| Check access | https://clerk.com/docs/guides/organizations/control-access/check-access |
-| Invitations | https://clerk.com/docs/guides/organizations/add-members/invitations |
-| OrganizationSwitcher | https://clerk.com/docs/reference/components/organization/organization-switcher |
-| Verified domains | https://clerk.com/docs/guides/organizations/verified-domains |
-| Enterprise SSO | https://clerk.com/docs/guides/organizations/add-members/sso |
+| Task | Reference |
+|------|-----------|
+| System permissions catalog, custom roles, role sets | references/roles-permissions.md |
+| Invitation lifecycle (create, list, revoke, built-in UI) | references/invitations.md |
+| Enterprise SSO setup, provider field access, domain verification | references/enterprise-sso.md |
+| Next.js-specific middleware, `redirect()`, route matchers | references/nextjs-patterns.md |
+
+## References
+
+| Reference | Description |
+|-----------|-------------|
+| `references/roles-permissions.md` | Default + custom roles, System Permissions catalog, permission naming |
+| `references/invitations.md` | Backend API for invitations + built-in UI |
+| `references/enterprise-sso.md` | SAML/OIDC per-org, domain verification, correct field access |
+| `references/nextjs-patterns.md` | Next.js middleware, `redirect()`, route protection |
+
+## Dashboard shortcuts
+
+| Action | URL |
+|---|---|
+| Enable Organizations + Membership mode | `https://dashboard.clerk.com/last-active?path=organizations-settings` |
+| Manage roles + permissions | `https://dashboard.clerk.com/last-active?path=organizations-settings/roles` |
+| Create/edit an organization | `https://dashboard.clerk.com/last-active?path=organizations` |
+| Webhooks for org events | `https://dashboard.clerk.com/last-active?path=webhooks` |
+
+## Documentation
+
+- [Overview](https://clerk.com/docs/guides/organizations/overview)
+- [Configure + enable](https://clerk.com/docs/guides/organizations/configure)
+- [Roles and permissions](https://clerk.com/docs/guides/organizations/control-access/roles-and-permissions)
+- [Check access](https://clerk.com/docs/guides/organizations/control-access/check-access)
+- [Invitations](https://clerk.com/docs/guides/organizations/add-members/invitations)
+- [OrganizationSwitcher](https://clerk.com/docs/reference/components/organization/organization-switcher)
+- [Verified domains](https://clerk.com/docs/guides/organizations/add-members/verified-domains)
+- [Enterprise SSO](https://clerk.com/docs/guides/organizations/add-members/sso)
 
 ## Key Patterns
 
-### 1. Get Organization from Auth
+Examples use `@clerk/nextjs` by default. For other frameworks swap the import to `@clerk/react` (Vite/CRA), `@clerk/astro/components`, `@clerk/vue`, `@clerk/expo`, `@clerk/react-router`, or `@clerk/tanstack-react-start` — the feature-level APIs (`has()`, `orgId`, `<OrganizationSwitcher />`, `<Show>`) are identical across SDKs. Framework-specific patterns (middleware, redirects) live in `references/nextjs-patterns.md`.
 
-Server-side access to organization:
+### 1. Read Organization from Auth
+
+Server-side access to active organization:
 
 ```typescript
 import { auth } from '@clerk/nextjs/server'
 
-const { orgId, orgSlug } = await auth()
-console.log(`Current org: ${orgSlug}`)
+const { orgId, orgSlug, orgRole } = await auth()
+if (!orgId) {
+  // user has no active org — either not in any, or viewing Personal Account
+}
 ```
+
+`auth()` is Next.js-specific. Equivalent APIs: `useAuth()` (React/Vue/Nuxt client), `getAuth(event)` (Nuxt/Astro server), composables (Vue). All return the same `orgId`/`orgSlug`/`orgRole` shape.
 
 ### 2. Dynamic Routes with Org Slug
 
-Create routes that accept org slug:
+Route-per-org pattern works in any framework supporting file-based dynamic routes. Next.js example:
 
 ```
 app/orgs/[slug]/page.tsx
 app/orgs/[slug]/settings/page.tsx
 ```
 
-Access the slug:
+Always verify the URL slug matches the active org slug — otherwise users can hit `/orgs/other-org/...` with a stale `orgSlug` in their session:
 
 ```typescript
-export default function DashboardPage({ params }: { params: { slug: string } }) {
-  return <div>Organization: {params.slug}</div>
-}
-```
-
-### 3. Check Organization Membership
-
-Verify user has access to specific org:
-
-```typescript
-import { auth } from '@clerk/nextjs/server'
-
-export default async function ProtectedPage() {
-  const { orgId, orgSlug } = await auth()
-
-  if (!orgId) {
-    return <div>Not in an organization</div>
+export default async function OrgPage({ params }: { params: { slug: string } }) {
+  const { orgSlug } = await auth()
+  if (orgSlug !== params.slug) {
+    redirect('/dashboard')  // or whatever your "no-access" flow is
   }
-
   return <div>Welcome to {orgSlug}</div>
 }
 ```
 
-### 4. Role-Based Access Control
-
-Check if user has specific role:
+### 3. Role-Based Access Control
 
 ```typescript
 const { has } = await auth()
@@ -102,115 +113,24 @@ if (!has({ role: 'org:admin' })) {
 }
 ```
 
-#### Custom Permissions
-
-Create custom roles and permissions in Dashboard → Organizations → Roles. Permission format: `org:resource:action`.
+Permission checks use the same `has()` surface:
 
 ```typescript
-// Server component — check a custom billing permission
-import { auth } from '@clerk/nextjs/server'
-import { redirect } from 'next/navigation'
-
-export default async function BillingPage() {
-  const { has } = await auth()
-
-  if (!has({ permission: 'org:billing:manage' })) {
-    redirect('/unauthorized')
-  }
-
-  return <BillingDashboard />
+if (!has({ permission: 'org:sys_memberships:manage' })) {
+  redirect('/unauthorized')
 }
 ```
 
-```typescript
-// Middleware — protect an entire route segment
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+**Permission naming convention.** System Permissions prefix with `org:sys_`; custom Permissions use `org:<resource>:<action>`. The full System Permissions catalog lives in `references/roles-permissions.md` — the short list is:
 
-const isBillingRoute = createRouteMatcher(['/orgs/:slug/billing(.*)'])
+- `org:sys_memberships:{read, manage}`
+- `org:sys_profile:{manage, delete}`
+- `org:sys_domains:{read, manage}`
+- `org:sys_billing:{read, manage}`
 
-export default clerkMiddleware(async (auth, req) => {
-  if (isBillingRoute(req)) {
-    await auth.protect({ permission: 'org:billing:manage' })
-  }
-})
-```
+Do NOT invent names like `org:create`, `org:manage_members`, `org:update_metadata` — those are not real permission slugs. See `references/roles-permissions.md` for custom roles and the permission table.
 
-```tsx
-// Client component — conditional rendering
-import { Show } from '@clerk/nextjs'
-
-<Show when={{ permission: 'org:billing:manage' }}>
-  <BillingSettings />
-</Show>
-```
-
-Permission naming convention: `org:resource:action` (e.g., `org:billing:manage`, `org:reports:view`, `org:api_keys:create`). Always prefix with `org:` for organization-scoped permissions.
-
-### 5. OrganizationSwitcher Component
-
-Let users switch between organizations:
-
-```typescript
-import { OrganizationSwitcher } from '@clerk/nextjs'
-
-export default function Nav() {
-  return (
-    <header>
-      <h1>Dashboard</h1>
-      <OrganizationSwitcher />
-    </header>
-  )
-}
-```
-
-## Default Roles
-
-All new members get assigned a role:
-
-| Role | Permissions |
-|------|-------------|
-| `org:admin` | Full access, manage members, settings |
-| `org:member` | Limited access, read-only |
-
-Custom roles can be created in the dashboard.
-
-## Default Permissions
-
-| Permission | Role |
-|-----------|------|
-| `org:create` | Can create new organizations |
-| `org:manage_members` | Can invite/remove members (default: admin) |
-| `org:manage_roles` | Can change member roles (default: admin) |
-| `org:update_metadata` | Can update org metadata (default: admin) |
-
-## Authorization Pattern
-
-Complete example protecting a route:
-
-```typescript
-import { auth } from '@clerk/nextjs/server'
-import { redirect } from 'next/navigation'
-
-export default async function AdminPage({ params }: { params: { slug: string } }) {
-  const { orgSlug, has } = await auth()
-
-  // Verify user is in the org
-  if (orgSlug !== params.slug) {
-    redirect('/dashboard')
-  }
-
-  // Check if admin
-  if (!has({ role: 'org:admin' })) {
-    redirect(`/orgs/${orgSlug}`)
-  }
-
-  return <div>Admin settings for {orgSlug}</div>
-}
-```
-
-## Conditional Rendering with `<Show>`
-
-Use `<Show>` for role-based conditional rendering in client components:
+### 4. Conditional Rendering with `<Show>`
 
 ```tsx
 import { Show } from '@clerk/nextjs'
@@ -219,191 +139,26 @@ import { Show } from '@clerk/nextjs'
   <AdminPanel />
 </Show>
 
-<Show when={{ permission: 'org:billing:manage' }}>
-  <BillingSettings />
+<Show when={{ permission: 'org:sys_memberships:manage' }}>
+  <MembersTab />
 </Show>
 ```
 
-> **Core 2 ONLY (skip if current SDK):** Use `<Protect role="org:admin">` and `<Protect permission="org:billing:manage">` instead of `<Show>`.
+> **Core 2 ONLY (skip if current SDK):** Use `<Protect role="org:admin">` / `<Protect permission="...">` instead of `<Show>`. `<Show>` replaced both `<Protect>` and `<SignedIn>`/`<SignedOut>` in Core 3.
 
-## Billing Checks
+Astro template syntax for the same component (imported from `@clerk/astro/components`):
 
-The `has()` method supports billing plan and feature checks for gating access:
-
-```typescript
-const { has } = await auth()
-
-has({ plan: 'gold' })        // Check subscription plan
-has({ feature: 'widgets' })  // Check feature entitlement
+```astro
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
 ```
 
-> **Core 2 ONLY (skip if current SDK):** `has()` only supports `role` and `permission` parameters. Billing checks are not available.
-
-## Session Tasks
-
-When personal accounts are disabled, users must choose an organization after sign-in. This is handled by the `choose-organization` session task:
+### 5. OrganizationSwitcher
 
 ```tsx
-import { TaskChooseOrganization } from '@clerk/nextjs'
+import { OrganizationSwitcher } from '@clerk/nextjs'
 
-// Renders when user must select an org
-<TaskChooseOrganization redirectUrlComplete="/dashboard" />
-```
-
-> **Core 2 ONLY (skip if current SDK):** Session tasks are not available. Use `<OrganizationSwitcher>` for org selection.
-
-## Enterprise SSO
-
-Organizations can use Enterprise SSO (SAML/OIDC) for member authentication:
-
-```typescript
-// Strategy name for Enterprise SSO
-strategy: 'enterprise_sso'
-
-// Access enterprise accounts on user object
-user.enterpriseAccounts
-```
-
-> **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` instead of `strategy: 'enterprise_sso'`, and `user.samlAccounts` instead of `user.enterpriseAccounts`.
-
-### Configuring Enterprise SSO per Organization
-
-Enterprise SSO is configured **per organization** in the Clerk Dashboard under Organizations > SSO Connections. Steps:
-
-1. Go to Dashboard → Organizations → select the org → SSO Connections
-2. Add a SAML or OIDC connection with the customer's IdP metadata
-3. Set the **verified domain** for the org — Clerk verifies ownership via DNS TXT record
-4. Once verified, users signing in with that email domain are automatically routed to the SSO flow and joined to the org
-
-```typescript
-// Check if the active user authenticated via enterprise SSO
-import { currentUser } from '@clerk/nextjs/server'
-
-const user = await currentUser()
-const ssoAccount = user?.enterpriseAccounts?.[0]
-
-if (ssoAccount) {
-  console.log(`SSO provider: ${ssoAccount.provider}`)
-  console.log(`SSO domain: ${ssoAccount.emailAddress}`)
-}
-```
-
-Key facts:
-- Strategy name: `enterprise_sso` (used in `signIn.supportedFirstFactors`)
-- Domain verification required: org claims a domain, Clerk verifies via DNS TXT record
-- Users with a verified email domain auto-join the org on first SSO sign-in
-- Each org can have multiple SSO connections (e.g., SAML + OIDC)
-
-## Gotchas
-
-### Capping Org Seats with `maxAllowedMemberships`
-
-Pass `maxAllowedMemberships` when creating an org to cap the number of seats. Attempts to add members beyond the cap will return an error.
-
-```typescript
-const clerk = await clerkClient()
-const org = await clerk.organizations.createOrganization({
-  name: 'Acme Corp',
-  createdBy: userId,
-  maxAllowedMemberships: 10,
-})
-```
-
-You can also update the cap after creation:
-
-```typescript
-await clerk.organizations.updateOrganization(orgId, {
-  maxAllowedMemberships: 25,
-})
-```
-
-### Billing Gates Permissions
-
-When Clerk Billing is enabled, `has({ permission: 'org:posts:edit' })` returns `false` if the Feature associated with that permission is not included in the organization's active Plan — even if the user has the permission assigned via their role. Billing gates permissions at the feature level. Ensure the required Feature is attached to the active Plan in Dashboard → Billing → Plans → Features before debugging role assignments.
-
-### Metadata Overwrites (Not Merges)
-
-`updateOrganization({ publicMetadata: { tier: 'enterprise' } })` REPLACES all public metadata, not merges it. Read first, spread, then write.
-
-Wrong:
-```typescript
-await clerk.organizations.updateOrganization(orgId, {
-  publicMetadata: { newField: 'value' },
-})
-```
-
-Right:
-```typescript
-const org = await clerk.organizations.getOrganization(orgId)
-await clerk.organizations.updateOrganization(orgId, {
-  publicMetadata: { ...org.publicMetadata, newField: 'value' },
-})
-```
-
-The same rule applies to `privateMetadata` and to user metadata via `clerkClient.users.updateUser`.
-
-## Common Pitfalls
-
-| Symptom | Cause | Solution |
-|---------|-------|----------|
-| `orgSlug` is undefined | Not calling `await auth()` | Use `const { orgSlug } = await auth()` |
-| Role check always fails | Not awaiting `auth()` | Add `await` before `auth()` |
-| Users can access other orgs | Not checking orgSlug matches URL | Verify `orgSlug === params.slug` |
-| Org not appearing in switcher | Organizations not enabled | Enable in Clerk Dashboard → Organizations |
-| Invitations not working | Wrong role configuration | Ensure members have invite role permissions |
-
-## Invitation API
-
-### Send an Invitation (Server Action / Route Handler)
-
-```typescript
-import { clerkClient } from '@clerk/nextjs/server'
-import { auth } from '@clerk/nextjs/server'
-
-export async function inviteMember(organizationId: string, emailAddress: string, role: string) {
-  const { has } = await auth()
-
-  if (!has({ permission: 'org:sys_memberships:manage' })) {
-    throw new Error('Not authorized to invite members')
-  }
-
-  const clerk = await clerkClient()
-  const invitation = await clerk.organizations.createOrganizationInvitation({
-    organizationId,
-    emailAddress,
-    role, // e.g. 'org:member' or 'org:admin'
-    redirectUrl: 'https://yourapp.com/accept-invite',
-  })
-
-  return invitation
-}
-```
-
-### List Pending Invitations
-
-```typescript
-const clerk = await clerkClient()
-const { data: invitations } = await clerk.organizations.getOrganizationInvitationList({
-  organizationId,
-  status: ['pending'], // 'pending' | 'accepted' | 'revoked'
-})
-```
-
-### Revoke an Invitation
-
-```typescript
-await clerk.organizations.revokeOrganizationInvitation({
-  organizationId,
-  invitationId,
-  requestingUserId: userId,
-})
-```
-
-### Built-in Invite UI
-
-`<OrganizationSwitcher />` includes a built-in member invitation UI when personal accounts are hidden:
-
-```tsx
 <OrganizationSwitcher
   hidePersonal
   afterCreateOrganizationUrl="/orgs/:slug/dashboard"
@@ -411,19 +166,185 @@ await clerk.organizations.revokeOrganizationInvitation({
 />
 ```
 
-The `<OrganizationProfile />` component also provides a full members management tab with invitation and role management.
+Key props:
+- `hidePersonal: boolean` — hide the Personal Account option. Defaults to `false`. Pass `true` for B2B-only apps.
+- `afterCreateOrganizationUrl`, `afterSelectOrganizationUrl`, `afterLeaveOrganizationUrl`, `afterSelectPersonalUrl` — navigation hooks. `:slug` is substituted at runtime.
+- `createOrganizationMode`, `organizationProfileMode` — `'modal' | 'navigation'` (default `'modal'`).
+
+The full prop list lives in the [component reference](https://clerk.com/docs/reference/components/organization/organization-switcher).
+
+### 6. Session Task — Choose Organization
+
+When `Membership required` is enabled (the default), users without an org are routed through a `choose-organization` session task after sign-in. Clerk handles this automatically inside `<SignIn />`, but you can host the UI yourself:
+
+```tsx
+import { ClerkProvider } from '@clerk/nextjs'
+
+<ClerkProvider taskUrls={{ 'choose-organization': '/session-tasks/choose-organization' }}>
+  {children}
+</ClerkProvider>
+```
+
+```tsx
+// app/session-tasks/choose-organization/page.tsx
+import { TaskChooseOrganization } from '@clerk/nextjs'
+
+export default function Page() {
+  return <TaskChooseOrganization redirectUrlComplete="/dashboard" />
+}
+```
+
+`TaskChooseOrganization` ships in `@clerk/nextjs`, `@clerk/react`, `@clerk/react-router`, `@clerk/tanstack-react-start`, `@clerk/js-frontend`.
+
+> **Core 2 ONLY (skip if current SDK):** Session tasks aren't available. Force an org selection at sign-in by redirecting to a page that renders `<OrganizationSwitcher hidePersonal />`.
+
+## Default Roles + System Permissions
+
+| Role | Default meaning |
+|------|-------------|
+| `org:admin` | Full access — all System Permissions, can manage org + memberships |
+| `org:member` | Read members + Read billing Permissions only |
+
+You can create up to 10 custom roles per instance in Dashboard → Organizations → Roles & Permissions. Role-per-org is controlled via **Role Sets** — see `references/roles-permissions.md` for the full model (custom roles, Creator/Default role settings, role sets, and the System Permissions catalog).
+
+## Billing Checks
+
+`has()` also supports plan and feature checks when Clerk Billing is enabled:
+
+```typescript
+const { has } = await auth()
+
+has({ plan: 'gold' })        // subscription plan
+has({ feature: 'widgets' })  // feature entitlement
+```
+
+> **Core 2 ONLY (skip if current SDK):** `has()` only supports `role` and `permission`. Billing checks aren't available.
+
+See `clerk-billing` for the full Billing surface and seat-limit plan model.
+
+## Enterprise SSO
+
+Per-org SAML/OIDC. Configured in Dashboard → Organizations → select org → SSO Connections. Requires domain verification (DNS TXT). Key fact: the `provider` field lives on `enterpriseConnection`, not on `enterpriseAccounts[0]` directly. See `references/enterprise-sso.md` for the correct access path and the verified-domains flow.
+
+```typescript
+// Strategy name for Enterprise SSO (Core 3)
+strategy: 'enterprise_sso'
+```
+
+> **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` and `user.samlAccounts` instead of `user.enterpriseAccounts`.
+
+## Gotchas
+
+### `maxAllowedMemberships` caps seats
+
+```typescript
+const clerk = await clerkClient()
+await clerk.organizations.createOrganization({
+  name: 'Acme Corp',
+  createdBy: userId,
+  maxAllowedMemberships: 10,
+})
+
+// Update later:
+await clerk.organizations.updateOrganization(orgId, {
+  maxAllowedMemberships: 25,
+})
+```
+
+For tier-based seat limits tied to a subscription, use a seat-limited Billing Plan (see `clerk-billing`).
+
+### Billing gates Permissions at the Feature level
+
+When Clerk Billing is enabled, `has({ permission: 'org:posts:edit' })` returns `false` if the Feature associated with that permission is not included in the organization's active Plan — even if the user has the Permission assigned via their role. Ensure the Feature is attached to the active Plan in Dashboard → Billing → Plans → Features.
+
+### Metadata updates REPLACE, not merge
+
+`updateOrganization({ publicMetadata })` overwrites all public metadata. Read first, spread, then write:
+
+```typescript
+const org = await clerk.organizations.getOrganization({ organizationId: orgId })
+await clerk.organizations.updateOrganization(orgId, {
+  publicMetadata: { ...org.publicMetadata, newField: 'value' },
+})
+```
+
+Applies identically to `privateMetadata` and to user metadata via `clerkClient.users.updateUser`.
+
+## Error Signatures (diagnose fast)
+
+Most "org-related" failures are configuration, not code. Do not edit components before checking these:
+
+| Error / symptom | Root cause | Fix |
+|---|---|---|
+| `orgId` / `orgSlug` is `undefined` for a signed-in user | Organizations not enabled for this instance, OR user has no active org (personal account) | Enable in Dashboard → Organizations; check Membership mode; surface `<OrganizationSwitcher />` |
+| `has({ permission: 'org:manage_members' })` always `false` | Using an invented permission slug | Use `org:sys_memberships:manage` (see roles-permissions.md catalog) |
+| `has({ role })` returns `false` but user looks like an admin | Session token stale after role change | Re-sign-in, or refresh the session: `await clerk.session?.reload()` |
+| `has({ permission })` `false` even with the role assigned | Feature not attached to active Plan (Billing gates permissions) | Dashboard → Billing → Plans → attach Feature |
+| `<OrganizationSwitcher />` doesn't show "Personal Account" | `Membership required` mode is on (the default since Aug 22, 2025) | Dashboard → Organizations settings → `Membership optional` |
+| `TaskChooseOrganization` throws "cannot render when a user doesn't have current session tasks" | Rendered outside a `choose-organization` task context | Wrap in a `choose-organization` session-task route only; don't render unconditionally |
+| `enterpriseAccounts[0].provider` is `undefined` | Accessing `provider` at the wrong nesting level | Use `user.enterpriseAccounts[0].enterpriseConnection?.provider` |
+
+## Authorization Pattern (Complete Example)
+
+Server component protecting a slug-scoped admin page:
+
+```typescript
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+
+export default async function AdminPage({ params }: { params: { slug: string } }) {
+  const { orgSlug, has } = await auth()
+
+  if (orgSlug !== params.slug) redirect('/dashboard')
+  if (!has({ role: 'org:admin' })) redirect(`/orgs/${orgSlug}`)
+
+  return <div>Admin settings for {orgSlug}</div>
+}
+```
+
+For middleware-level protection (Next.js) see `references/nextjs-patterns.md`.
+
+## Invitations (short form)
+
+Send from a server action or route handler:
+
+```typescript
+import { clerkClient, auth } from '@clerk/nextjs/server'
+
+export async function inviteMember(organizationId: string, emailAddress: string, role: string) {
+  const { userId, has } = await auth()
+
+  if (!userId) throw new Error('Not signed in')
+  if (!has({ permission: 'org:sys_memberships:manage' })) {
+    throw new Error('Not authorized to invite members')
+  }
+
+  const clerk = await clerkClient()
+  return clerk.organizations.createOrganizationInvitation({
+    organizationId,
+    inviterUserId: userId,       // required per Backend API
+    emailAddress,
+    role,                        // e.g. 'org:admin' or 'org:member'
+    redirectUrl: 'https://yourapp.com/accept-invite',
+  })
+}
+```
+
+The full lifecycle (list, revoke, bulk create, built-in `<OrganizationProfile />` UI) lives in `references/invitations.md`.
 
 ## Workflow
 
-1. **Setup** - Enable Organizations in Clerk Dashboard
-2. **Create org** - Users create org or admin creates via API
-3. **Add members** - Send invitations or add directly
-4. **Assign roles** - Default member role, promote to admin as needed
-5. **Build protected routes** - Use auth() to check orgSlug and roles
-6. **Use OrganizationSwitcher** - Let users switch between orgs
+1. **Enable** — Organizations + Membership mode in Dashboard
+2. **Create org** — via UI component or Backend API
+3. **Invite members** — Backend API or built-in UI, with `inviterUserId`
+4. **Gate access** — `has({ role })` / `has({ permission })` with canonical `org:sys_*` names
+5. **Scope routes** — `orgSlug === params.slug` on every protected page
+6. **Switch orgs** — `<OrganizationSwitcher />` handles the whole flow
 
 ## See Also
 
-- `clerk-setup` - Initial Clerk install
-- `clerk-webhooks` - Sync org events to your database
-- `clerk-backend-api` - Manage members programmatically
+- `clerk-setup` — Initial Clerk install
+- `clerk-billing` — Seat-limit plans, per-plan billing, `has({ plan })` / `has({ feature })`
+- `clerk-webhooks` — Sync org events to your database (`organization.created`, `organizationMembership.*`)
+- `clerk-backend-api` — Full Backend API reference
+- `clerk-nextjs-patterns` — Framework-specific middleware, server actions, caching

--- a/skills/features/clerk-orgs/evals/evals.json
+++ b/skills/features/clerk-orgs/evals/evals.json
@@ -23,6 +23,7 @@
 				"Uses has({ role: 'org:admin' }) from auth() rather than comparing orgRole string directly",
 				"Destructures has from the result of await auth() (not from useAuth or a non-awaited call)",
 				"Does NOT hardcode role strings without using Clerk's role system",
+				"If it uses a permission check, uses a canonical System Permission slug like org:sys_memberships:manage, NOT invented slugs like org:manage_members, org:create, or org:update_metadata",
 				"Settings page shows org-level configuration options",
 				"Regular members can still access the dashboard"
 			]
@@ -62,7 +63,8 @@
 				"Mentions configuring Enterprise SSO in the Clerk Dashboard for the specific organization",
 				"Explains that domain verification via DNS TXT record is required before SSO-signed users auto-join the org",
 				"References user.enterpriseAccounts (NOT user.samlAccounts) to access SSO session data",
-				"Shows how to check if a user signed in via SSO (enterpriseAccounts or session data)",
+				"Uses strategy: 'enterprise_sso' (NOT 'saml')",
+				"If accessing provider metadata, reads it from user.enterpriseAccounts[i].enterpriseConnection?.provider (NOT directly from user.enterpriseAccounts[i].provider — that field does not exist on EnterpriseAccount)",
 				"Does NOT suggest implementing SAML from scratch (Clerk handles the protocol)"
 			]
 		},
@@ -86,10 +88,25 @@
 			"scaffold": "nextjs-basic-auth",
 			"expectations": [
 				"Checks the caller has invite permission using has({ permission: 'org:sys_memberships:manage' }) before sending invitations",
-				"Calls clerk.organizations.createOrganizationInvitation with organizationId, emailAddress, role, and redirectUrl",
-				"Lists pending invitations by calling getOrganizationInvitationList with status: ['pending']",
-				"Only authorized users (admins or members with invite permission) can send invitations",
+				"Calls clerk.organizations.createOrganizationInvitation with organizationId, inviterUserId (the calling userId), emailAddress, role, and redirectUrl",
+				"Does NOT omit inviterUserId — it is required for human-initiated invitations",
+				"Lists pending invitations by calling getOrganizationInvitationList with status array",
+				"If filtering status, uses only the canonical values: 'pending', 'accepted', 'revoked', 'expired' (not made-up states)",
+				"Only authorized users (admins or members with org:sys_memberships:manage) can send invitations",
 				"Uses await clerkClient() (not clerkClient directly) to obtain the client instance before making API calls"
+			]
+		},
+		{
+			"id": 9,
+			"prompt": "i enabled organizations in clerk but my b2c users can't access the pricing page anymore. OrganizationSwitcher also doesn't show 'Personal account'. what happened?",
+			"expected_output": "Membership required is the default mode since Aug 22, 2025 — it disables personal accounts. B2C + B2B coexistence needs Membership optional.",
+			"scaffold": "nextjs-basic-auth",
+			"expectations": [
+				"Identifies that Membership required is the DEFAULT mode in Clerk Organizations (since Aug 22, 2025)",
+				"Explains that Membership required disables personal accounts, so users without an active org are excluded from <PricingTable />, <OrganizationSwitcher />'s personal tab, and anything tied to user-level identity",
+				"Directs user to Dashboard → Organizations settings → toggle to Membership optional",
+				"Does NOT suggest changing code before flipping the Dashboard toggle",
+				"Does NOT claim this requires deleting and re-enabling Organizations"
 			]
 		},
 		{

--- a/skills/features/clerk-orgs/references/enterprise-sso.md
+++ b/skills/features/clerk-orgs/references/enterprise-sso.md
@@ -1,0 +1,108 @@
+# Enterprise SSO
+
+Per-organization SAML or OIDC. Configured in Dashboard → Organizations → select org → SSO Connections. Domain-verified. Users with a verified email domain auto-join the org on first SSO sign-in.
+
+## Configuration Flow
+
+1. Open Dashboard → Organizations → select the org → **SSO Connections**
+2. Add a SAML or OIDC connection with the customer's IdP metadata
+3. Set the **Verified Domain** for the org — Clerk verifies ownership via DNS TXT record
+4. Once verified, users signing in with a matching email domain are routed through the SSO flow and auto-joined to the org
+
+Each org can have multiple SSO connections (e.g., SAML + OIDC, or SAML for two different IdPs).
+
+Permission required to manage: `org:sys_domains:manage`.
+
+## Strategy Name
+
+```typescript
+// Current SDK (Core 3+)
+strategy: 'enterprise_sso'
+```
+
+Used in `signIn.supportedFirstFactors` when building custom sign-in flows.
+
+> **Core 2 ONLY (skip if current SDK):** Uses `strategy: 'saml'` and `user.samlAccounts` instead of the Core 3 names.
+
+## Accessing SSO Info on the User
+
+This is where the skill used to hallucinate the wrong shape. The correct access paths:
+
+```typescript
+import { currentUser } from '@clerk/nextjs/server'
+
+const user = await currentUser()
+const ssoAccount = user?.enterpriseAccounts?.[0]
+
+if (ssoAccount) {
+  // Directly on EnterpriseAccount:
+  ssoAccount.emailAddress           // the email used for SSO
+  ssoAccount.active                 // boolean — is the account active
+  ssoAccount.firstName, ssoAccount.lastName
+  ssoAccount.lastAuthenticatedAt    // Date | null
+
+  // Provider metadata lives on the nested EnterpriseAccountConnection:
+  const conn = ssoAccount.enterpriseConnection
+  conn?.provider    // 'saml_okta' | 'saml_google' | 'saml_microsoft' | 'saml_custom' | 'oauth_<provider>'
+  conn?.protocol    // 'saml' | 'oauth'
+  conn?.domain      // the verified domain
+  conn?.name        // display name of the connection
+  conn?.active
+}
+```
+
+### Common Mistakes
+
+```typescript
+// ❌ Wrong — `provider` is not a field on EnterpriseAccount
+ssoAccount.provider
+
+// ✓ Right — `provider` lives on the nested connection
+ssoAccount.enterpriseConnection?.provider
+```
+
+`enterpriseConnection` is `null` if the connection was deleted after the account was provisioned. Always guard with `?.`.
+
+## Verified Domains
+
+A Verified Domain is an email domain (e.g. `acme.com`) that the org has proven ownership of via DNS TXT record. Once verified:
+
+- Users with `someone@acme.com` emails can auto-join the org
+- Enterprise SSO connections can be attached to the domain
+- Controlled by `org:sys_domains:manage` Permission
+
+Enrollment modes for verified domains:
+
+| Mode | Behavior |
+|------|----------|
+| Manual invitation | Admin must invite each user individually |
+| Automatic invitation | Clerk auto-sends invitations to anyone signing up with the domain |
+| Automatic suggestion | Matching users see a prompt to join the org |
+
+Configure per-domain in Dashboard → Organizations → select org → Verified Domains.
+
+## Custom Sign-In Flow with SSO
+
+Typical pattern:
+
+```typescript
+const { signIn } = useSignIn()
+
+// Start SSO — Clerk redirects to the IdP and back
+await signIn.authenticateWithRedirect({
+  strategy: 'enterprise_sso',
+  identifier: emailAddress,
+  redirectUrl: '/sso-callback',
+  redirectUrlComplete: '/dashboard',
+})
+```
+
+The `identifier` is the user's email. Clerk uses the domain to route to the correct Enterprise SSO connection. If no matching connection exists, the sign-in falls back to standard email/password or returns an error.
+
+## Key Rules
+
+- **`provider` is nested.** Always `enterpriseAccounts[i].enterpriseConnection?.provider` — not directly on the account.
+- **Domain verification first.** SSO doesn't work until the org has at least one Verified Domain.
+- **Strategy name matters.** Core 3 uses `'enterprise_sso'`; Core 2 used `'saml'`. They are NOT interchangeable.
+- **Multiple connections per org is fine.** Typical enterprise: one SAML connection to Okta + one OIDC to Azure AD for different user segments.
+- **Auto-join on first SSO sign-in.** Users with a matching verified email domain are added to the org without an invitation.

--- a/skills/features/clerk-orgs/references/invitations.md
+++ b/skills/features/clerk-orgs/references/invitations.md
@@ -1,0 +1,137 @@
+# Organization Invitations
+
+Send, list, revoke. Backend API methods live on `clerkClient().organizations.*`. All send operations require the caller to have `org:sys_memberships:manage`.
+
+## Create Invitation
+
+```typescript
+import { clerkClient, auth } from '@clerk/nextjs/server'
+
+export async function inviteMember(organizationId: string, emailAddress: string, role: string) {
+  const { userId, has } = await auth()
+  if (!userId) throw new Error('Not signed in')
+  if (!has({ permission: 'org:sys_memberships:manage' })) {
+    throw new Error('Not authorized')
+  }
+
+  const clerk = await clerkClient()
+  return clerk.organizations.createOrganizationInvitation({
+    organizationId,
+    inviterUserId: userId,
+    emailAddress,
+    role,
+    redirectUrl: 'https://yourapp.com/accept-invite',
+    publicMetadata: { invitedFrom: 'admin-panel' },
+  })
+}
+```
+
+**Params:**
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `organizationId` | `string` | Required |
+| `inviterUserId` | `string \| null` | Required. The user sending the invite. Pass `null` only for system-originated invites (rare). |
+| `emailAddress` | `string` | Required. Target email. |
+| `role` | `string` | Required. `'org:admin'`, `'org:member'`, or any custom role slug. |
+| `redirectUrl?` | `string` | Where the user lands after accepting. |
+| `publicMetadata?` | `object` | Readable by Frontend + Backend; settable only from Backend. |
+
+**Rate limit:** 250 requests/hour per application instance.
+
+## Bulk Create
+
+```typescript
+await clerk.organizations.createOrganizationInvitationBulk({
+  organizationId,
+  inviterUserId: userId,
+  invitations: [
+    { emailAddress: 'alice@acme.com', role: 'org:admin' },
+    { emailAddress: 'bob@acme.com', role: 'org:member' },
+  ],
+})
+```
+
+## List Invitations
+
+```typescript
+const { data, totalCount } = await clerk.organizations.getOrganizationInvitationList({
+  organizationId,
+  status: ['pending', 'accepted', 'revoked', 'expired'],  // any subset; defaults to ['pending']
+  limit: 50,         // max 500
+  offset: 0,
+})
+```
+
+Returns a `PaginatedResourceResponse<OrganizationInvitation[]>` — access the array via `data` and the total via `totalCount`.
+
+Full status enum: `'pending' | 'accepted' | 'revoked' | 'expired'`. Skipping `status` defaults to `['pending']`.
+
+## Revoke Invitation
+
+```typescript
+await clerk.organizations.revokeOrganizationInvitation({
+  organizationId,
+  invitationId,
+  requestingUserId: userId,  // the user doing the revoking
+})
+```
+
+All three params are required strings. You cannot revoke an already-accepted invitation (use membership removal APIs for that).
+
+## Get a Single Invitation
+
+```typescript
+const invitation = await clerk.organizations.getOrganizationInvitation({
+  organizationId,
+  invitationId,
+})
+```
+
+## Built-in Invitation UI
+
+Zero-code path — `<OrganizationProfile />` includes a full members tab with invite / revoke / role change:
+
+```tsx
+import { OrganizationProfile } from '@clerk/nextjs'
+
+export default function OrgSettings() {
+  return <OrganizationProfile />
+}
+```
+
+`<OrganizationSwitcher />` also includes a compact invitation flow via its built-in dropdown when `hidePersonal` is set or users click **Manage Organization**:
+
+```tsx
+<OrganizationSwitcher
+  hidePersonal
+  afterCreateOrganizationUrl="/orgs/:slug/dashboard"
+  afterSelectOrganizationUrl="/orgs/:slug/dashboard"
+/>
+```
+
+## Accept Invitations (Custom Flow)
+
+If you need to build your own accept page instead of relying on Clerk's account portal, see the custom flow doc: [Accept Organization Invitations](https://clerk.com/docs/guides/development/custom-flows/organizations/accept-organization-invitations). Common pattern:
+
+1. User clicks link → lands on your `/accept-invite` page with `?__clerk_ticket=...` query param
+2. Your page calls `signIn.create({ strategy: 'ticket', ticket })` OR `signUp.create({ strategy: 'ticket', ticket })` depending on whether the user exists
+3. Clerk sets the active org on the session
+
+## Webhook Events
+
+Listen for invitation lifecycle:
+
+- `organizationInvitation.created`
+- `organizationInvitation.accepted`
+- `organizationInvitation.revoked`
+
+See `clerk-webhooks` skill for webhook setup + signature verification.
+
+## Key Rules
+
+- `inviterUserId` is NOT optional in a human-initiated flow. Don't omit it — track who sent each invite.
+- Invitations with `status: 'expired'` need to be recreated; they can't be re-sent.
+- The caller needs `org:sys_memberships:manage`. Default `org:admin` has this; `org:member` does not.
+- Revoke by `invitationId`, not by email. Email alone is ambiguous when you've had multiple invites to the same address.
+- Bulk create is rate-limited the same as single create (250/hr application-wide). Batch wisely.

--- a/skills/features/clerk-orgs/references/nextjs-patterns.md
+++ b/skills/features/clerk-orgs/references/nextjs-patterns.md
@@ -1,0 +1,146 @@
+# Next.js Patterns for Organizations
+
+Framework-specific pieces for `@clerk/nextjs` v7+: middleware-level route protection, `next/navigation`'s `redirect()`, and route matchers for org-scoped URL segments. Conceptual content lives in the main SKILL.md.
+
+For other frameworks see:
+- `clerk-react-patterns` (Vite/CRA)
+- `clerk-astro-patterns`
+- `clerk-nextjs-patterns` (broader Next.js patterns beyond orgs)
+
+## Protecting Routes in Middleware
+
+Next.js middleware runs before the request hits your page, so you can reject unauthorized traffic without rendering anything:
+
+```typescript
+// proxy.ts (Next.js 16+) or middleware.ts (Next.js <=15)
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+const isOrgAdminRoute = createRouteMatcher(['/orgs/:slug/admin(.*)'])
+const isBillingRoute = createRouteMatcher(['/orgs/:slug/billing(.*)'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isOrgAdminRoute(req)) {
+    await auth.protect({ role: 'org:admin' })
+  }
+
+  if (isBillingRoute(req)) {
+    await auth.protect({ permission: 'org:sys_billing:manage' })
+  }
+})
+
+export const config = {
+  matcher: [
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/(api|trpc)(.*)',
+  ],
+}
+```
+
+`auth.protect({ ... })` accepts the same shape as `has()` — `{ role }`, `{ permission }`, or a callback `condition: (has) => boolean`.
+
+## Server Component Redirects
+
+Use `redirect()` from `next/navigation` to short-circuit rendering after an auth check. `redirect()` throws a special error Next.js handles internally — don't wrap it in try/catch:
+
+```typescript
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+
+export default async function AdminPage({ params }: { params: { slug: string } }) {
+  const { orgSlug, has } = await auth()
+
+  if (orgSlug !== params.slug) redirect('/dashboard')
+  if (!has({ role: 'org:admin' })) redirect(`/orgs/${orgSlug}`)
+
+  return <AdminContent />
+}
+```
+
+## Route Matchers with Org Slugs
+
+`createRouteMatcher` accepts the same path syntax as Next.js App Router dynamic segments — `:slug` captures a path parameter:
+
+```typescript
+const isOrgRoute = createRouteMatcher([
+  '/orgs/:slug',
+  '/orgs/:slug/(.*)',
+])
+```
+
+Note: `:slug` in the matcher is NOT automatically bound to the `orgSlug` from `auth()`. You still need to verify they match inside the page:
+
+```typescript
+const { orgSlug } = await auth()
+if (orgSlug !== params.slug) redirect('/dashboard')
+```
+
+Otherwise a user with an active `acme` org can hit `/orgs/other-org/...` URLs and confuse your data layer.
+
+## Server Actions + Orgs
+
+```typescript
+'use server'
+import { auth } from '@clerk/nextjs/server'
+
+export async function createProject(name: string) {
+  const { orgId, userId, has } = await auth()
+
+  if (!userId) throw new Error('Not signed in')
+  if (!orgId) throw new Error('No active organization')
+  if (!has({ permission: 'org:projects:create' })) {
+    throw new Error('Not authorized')
+  }
+
+  // scope the write by orgId so data can never leak across orgs
+  return db.projects.create({ data: { name, orgId, createdBy: userId } })
+}
+```
+
+Pattern: **always scope server actions by `orgId`** at the database layer. Don't trust the client to send the right org.
+
+## API Routes
+
+```typescript
+// app/api/orgs/[slug]/members/route.ts
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { orgSlug, orgId, has } = await auth()
+  const { slug } = await params
+
+  if (orgSlug !== slug) {
+    return NextResponse.json({ error: 'wrong org' }, { status: 403 })
+  }
+  if (!has({ permission: 'org:sys_memberships:read' })) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const clerk = await clerkClient()
+  const { data } = await clerk.organizations.getOrganizationMembershipList({
+    organizationId: orgId!,
+  })
+
+  return NextResponse.json({ members: data })
+}
+```
+
+Return `403` (forbidden) when the user is authenticated but lacks permission; `401` (unauthenticated) when there's no session.
+
+## File Naming
+
+- `proxy.ts` — Next.js 16+ (current)
+- `middleware.ts` — Next.js <=15 (Core 2 era and earlier)
+
+Both use the same `clerkMiddleware` export. Only the filename changed. If you're on Next.js 16 with cache components, `ClerkProvider` must also move inside `<body>` — see the Core 3 upgrade guide.
+
+## Key Rules
+
+- **Validate `orgSlug === params.slug` on every org-scoped page.** The slug in the URL is an identifier; the active org in the session is the authority. Don't let them diverge.
+- **Scope database writes by `orgId`.** Never trust the client to supply it.
+- **Use `auth.protect()` in middleware**, `redirect()` in server components. Don't try to `redirect()` from middleware — use `NextResponse.redirect()` or let `auth.protect()` handle it.
+- **`redirect()` throws** — it doesn't return. Don't put code after it expecting to run.
+- **Middleware is fast-path protection**, not a replacement for page-level checks. Defense in depth: middleware catches 95%, page-level catches the edge cases.

--- a/skills/features/clerk-orgs/references/roles-permissions.md
+++ b/skills/features/clerk-orgs/references/roles-permissions.md
@@ -1,0 +1,120 @@
+# Roles and Permissions
+
+Clerk Organizations use Role-Based Access Control (RBAC). Every member has one Role per org; Roles carry Permissions (a mix of Clerk-provided System Permissions and your own custom Permissions).
+
+## Default Roles
+
+| Role | Default meaning |
+|------|-----------------|
+| `org:admin` | Full access — holds all System Permissions, can manage the Organization and its memberships |
+| `org:member` | Read-only members. By default has only `org:sys_memberships:read` and `org:sys_billing:read` |
+
+Both slugs are automatically created when Organizations are enabled. You cannot delete a default Role if it's set as the org's **Creator** or **Default** Role — reassign to another Role first.
+
+## System Permissions (canonical catalog)
+
+These are the only built-in Permissions. Use them verbatim; do NOT invent shorter forms like `org:manage_members` or `org:create`.
+
+| Slug | Purpose |
+|------|---------|
+| `org:sys_profile:manage` | Edit Organization profile (name, slug, logo) |
+| `org:sys_profile:delete` | Delete the Organization |
+| `org:sys_memberships:read` | View the member list |
+| `org:sys_memberships:manage` | Invite, remove, and change roles of members |
+| `org:sys_domains:read` | View Verified Domains |
+| `org:sys_domains:manage` | Add / verify / remove Verified Domains and Enterprise SSO connections |
+| `org:sys_billing:read` | View billing info (subscription, invoices) |
+| `org:sys_billing:manage` | Manage billing (change plan, payment method) |
+
+**Creator Role requirement.** The Role that Clerk assigns to a user who creates a new Organization MUST carry at minimum:
+
+- `org:sys_memberships:manage`
+- `org:sys_memberships:read`
+- `org:sys_profile:delete`
+
+If you reassign the Creator Role, ensure the replacement Role has these three at minimum.
+
+## Custom Roles
+
+Up to 10 custom Roles per instance. Create in Dashboard → Roles & Permissions → **Add role**. The key follows `org:<role>` format. Examples:
+
+- `org:billing` — carries `org:sys_billing:manage`
+- `org:reports_viewer` — carries your custom `org:reports:view`
+
+## Custom Permissions
+
+Naming convention: `org:<resource>:<action>`. Examples: `org:reports:view`, `org:api_keys:create`, `org:posts:edit`.
+
+Create in Dashboard → Roles & Permissions → **Permissions** tab → **Add permission**. Permissions are attached to Roles inside a Role Set.
+
+## Role Sets
+
+Roles are surfaced to Organizations through **Role Sets** — this controls which Roles can be assigned within a given Organization. Each Organization is assigned exactly one Role Set.
+
+Default behavior: all orgs share the default Role Set. If you need per-org role variations (e.g. one customer org has its own `org:support` role), create a second Role Set and assign it.
+
+## Billing Gates Permissions
+
+When Clerk Billing is enabled, a custom Permission `org:<feature>:<action>` only returns `true` from `has()` if the `<feature>` part matches a Feature included in the organization's active Plan.
+
+Example: user has role `org:admin` with Permission `org:posts:edit`. `has({ permission: 'org:posts:edit' })` returns:
+
+- `false` — if the active Plan does not include the `posts` Feature
+- `true` — if the active Plan includes the `posts` Feature
+
+This applies regardless of role assignment. See `clerk-billing` skill for the full feature-vs-plan model.
+
+## Change a User's Role
+
+Via Backend API:
+
+```typescript
+import { clerkClient } from '@clerk/nextjs/server'
+
+const clerk = await clerkClient()
+await clerk.organizations.updateOrganizationMembership({
+  organizationId: 'org_123',
+  userId: 'user_123',
+  role: 'org:admin',
+})
+```
+
+Via Dashboard: Users → select member → change role dropdown.
+
+Via UI: the `<OrganizationProfile />` component's Members tab includes a role-change dropdown for admins.
+
+## Checking Roles and Permissions
+
+Three surfaces, same semantics:
+
+```typescript
+// Server (Next.js)
+import { auth } from '@clerk/nextjs/server'
+const { has } = await auth()
+has({ role: 'org:admin' })
+has({ permission: 'org:sys_memberships:manage' })
+```
+
+```tsx
+// Client (any React-based SDK)
+import { useAuth } from '@clerk/nextjs'
+const { has, isLoaded } = useAuth()
+if (!isLoaded) return null
+has?.({ role: 'org:admin' })
+```
+
+```tsx
+// JSX conditional
+import { Show } from '@clerk/nextjs'
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
+```
+
+## Key Rules
+
+- **Never invent permission slugs.** If you don't see it in the System Permissions catalog above or you haven't created it as a custom Permission in Dashboard, it doesn't exist.
+- **`org:` prefix is mandatory** for all org-scoped permissions.
+- **Always check `isLoaded` before trusting `has` on the client.** On first render `has` can be `undefined` — use optional chaining (`has?.()`) or guard on `isLoaded`.
+- **Case-sensitive.** `org:Admin` is not `org:admin`.
+- **Role changes require session refresh.** If you change a user's role and `has()` still returns the old value, the session token is stale. `await clerk.session?.reload()` on the client, or navigate to force a new session.


### PR DESCRIPTION
## Summary

Refreshes `clerk-orgs` to match `clerk-billing` v2 structure: progressive disclosure, `compatibility:` frontmatter, error-signatures table, dashboard shortcuts, task-routing table. Content cross-referenced against current docs + `@clerk/backend` / `@clerk/shared` types.

## Content

- Permission slugs aligned with canonical System Permissions (`org:sys_memberships:*`, `org:sys_profile:*`, `org:sys_domains:*`, `org:sys_billing:*`).
- `createOrganizationInvitation` includes required `inviterUserId`.
- Enterprise SSO accesses `provider` via `enterpriseAccounts[i].enterpriseConnection?.provider` per the `EnterpriseAccountConnection` type.
- `getOrganizationInvitationList` status enum covers all four values (`pending | accepted | revoked | expired`).
- Membership required / optional mode surfaced (default since 2025-08-22, affects B2C coexistence).

## Structural

- SKILL.md 423 → 350 lines.
- `@clerk/nextjs` as default with explicit pointers to other SDKs (addresses the React/Next over-indexing concern raised in thread).
- Next.js middleware + route matchers moved to `references/nextjs-patterns.md`.
- Four new references: `roles-permissions.md`, `invitations.md`, `enterprise-sso.md`, `nextjs-patterns.md`.
- Frontmatter `inputs:` → `compatibility:`. Version 2.1.0 → 3.0.0.

## Evals

- Eval 2 — canonical permission slugs.
- Eval 5 — `enterpriseConnection?.provider` path.
- Eval 7 — `inviterUserId` + full status enum.
- Eval 9 (new) — Membership mode prerequisite.

## Test plan

- [ ] Run the skill against the 9 eval prompts (pass rate vs baseline).
- [ ] Local smoke: install via `npx skills add clerk/skills -s clerk-orgs` in a Next.js app with Organizations enabled; verify `<OrganizationSwitcher />` + `has()` patterns render as described.
- [ ] Cross-link check: references resolve from `What Do You Need?` routing table.