### PR TITLE
refactor(webhooks): modernize handlers + framework coverage

### DIFF
--- a/skills/features/clerk-webhooks/SKILL.md
+++ b/skills/features/clerk-webhooks/SKILL.md
@@ -1,28 +1,38 @@
 ---
 name: clerk-webhooks
-description: Clerk webhooks for real-time events and data syncing. Always output complete,
-  copy-paste-ready webhook handlers with verifyWebhook(req) verification. Listen for
-  user creation, updates, deletion, and organization events. Build event-driven features
-  like database sync, notifications, integrations.
+description: Clerk webhooks for real-time events and data syncing. Verify with verifyWebhook
+  from the framework-specific package. Handle user, session, organization, billing, and
+  payment events. Build event-driven features like database sync, notifications, and
+  integrations.
 allowed-tools: WebFetch
 license: MIT
 metadata:
   author: clerk
   version: 1.2.0
-compatibility: Requires CLERK_WEBHOOK_SECRET (svix signing secret from Clerk dashboard)
+compatibility: Requires CLERK_WEBHOOK_SIGNING_SECRET (svix signing secret from Clerk dashboard)
 ---
 
 # Webhooks
 
-Always output complete, working, copy-paste-ready webhook handlers. Never output stubs, placeholders, or partial implementations. Include `verifyWebhook(req)` in every handler.
+Output complete, working webhook handlers with `verifyWebhook(req)` verification in every handler.
 
-## CRITICAL: Always Verify Webhooks
+## When to Use Webhooks
 
-**NEVER skip signature verification**, even for notification-only handlers. Always use `verifyWebhook(req)` from `@clerk/nextjs/webhooks`. This uses the `CLERK_WEBHOOK_SECRET` env var automatically.
+Webhooks are **asynchronous and eventually consistent**. Delivery is fast but not guaranteed to be immediate, and may occasionally fail (Svix retries on a fixed schedule). Use them for:
 
-## CRITICAL: Make Webhook Route Public
+- Database sync (a separate users / orgs table that follows Clerk)
+- Notifications (welcome emails, Slack pings, internal alerts)
+- Integrations triggered by lifecycle events
 
-Webhook routes MUST be excluded from Clerk middleware protection. Without this, Clerk returns 401.
+Do NOT rely on webhook delivery as part of a synchronous flow such as onboarding ("user signs up, then we read X from our DB"). For data the user just created, read it from the [Clerk session token](https://clerk.com/docs/guides/sessions/session-tokens) or call the Backend API directly. Webhooks fill the gap when you need data about *other* users or events the session token doesn't carry.
+
+## Verify Every Webhook
+
+Use `verifyWebhook(req)` from the framework-specific package (`@clerk/nextjs/webhooks`, `@clerk/express/webhooks`, etc.). It reads `CLERK_WEBHOOK_SIGNING_SECRET` automatically and throws on bad signatures. Skipping verification, even for notification-only handlers, exposes the endpoint to spoofed events.
+
+## Make the Webhook Route Public
+
+Webhook routes must be excluded from Clerk middleware protection. Without this, Clerk returns 401.
 
 ```typescript
 // proxy.ts (Next.js <=15: middleware.ts)
@@ -30,8 +40,8 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
 const isPublicRoute = createRouteMatcher(['/api/webhooks(.*)'])
 
-export default clerkMiddleware((auth, req) => {
-  if (!isPublicRoute(req)) auth().protect()
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) await auth.protect()
 })
 ```
 
@@ -47,7 +57,7 @@ export async function POST(req: NextRequest) {
   // ALWAYS verify - never skip, even for notification-only handlers
   let evt
   try {
-    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SECRET automatically
+    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SIGNING_SECRET automatically
   } catch (err) {
     console.error('Webhook verification failed:', err)
     return new Response('Verification failed', { status: 400 })
@@ -91,7 +101,7 @@ export async function POST(req: NextRequest) {
 
 ## Full Example: Welcome Email (Resend) + Slack Notification on user.created
 
-**ALWAYS use this COMPLETE pattern — never stub it out:**
+Notification-only handlers still verify the signature. Same pattern as the database-sync handler:
 
 ```typescript
 // app/api/webhooks/route.ts
@@ -105,7 +115,7 @@ export async function POST(req: NextRequest) {
   // Step 1: ALWAYS verify the webhook signature - NEVER skip this
   let evt
   try {
-    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SECRET env var
+    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SIGNING_SECRET env var
   } catch (err) {
     console.error('Webhook verification failed:', err)
     return new Response('Verification failed', { status: 400 })
@@ -146,8 +156,8 @@ export async function POST(req: NextRequest) {
 // proxy.ts (Next.js <=15: middleware.ts)
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 const isPublicRoute = createRouteMatcher(['/api/webhooks(.*)'])
-export default clerkMiddleware((auth, req) => {
-  if (!isPublicRoute(req)) auth().protect()
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) await auth.protect()
 })
 ```
 
@@ -163,7 +173,7 @@ export async function POST(req: NextRequest) {
   // ALWAYS verify signature - never skip, even for simple handlers
   let evt
   try {
-    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SECRET env var
+    evt = await verifyWebhook(req) // uses CLERK_WEBHOOK_SIGNING_SECRET env var
   } catch (err) {
     console.error('Webhook verification failed:', err)
     return new Response('Verification failed', { status: 400 })
@@ -215,59 +225,26 @@ export async function POST(req: NextRequest) {
 }
 ```
 
-## Express.js Webhook Handler
+## Other Frameworks
 
-> **CRITICAL**: Use `express.raw()` NOT `express.json()` for webhook routes. Signature verification requires the raw body bytes. `express.json()` parses the body and breaks verification.
+For Express, Astro, Fastify, Nuxt, React Router, and TanStack Start, use the framework-specific `verifyWebhook` adapter. Each Clerk SDK package ships its own (`@clerk/express/webhooks`, `@clerk/astro/webhooks`, `@clerk/fastify/webhooks`, etc.).
+
+See `references/frameworks.md` for full handler examples per framework.
+
+## Type Narrowing for `evt.data`
+
+`verifyWebhook` returns `WebhookEvent`, a discriminated union of all event types. Narrow with `evt.type` to get type-safe access to `evt.data`:
 
 ```typescript
-import express from 'express'
-import { Webhook } from 'svix'
+const evt = await verifyWebhook(req)
 
-const app = express()
-
-// WRONG - breaks verification because it parses the body:
-// app.use(express.json())
-
-// CORRECT - use raw body for webhook route only:
-app.post('/webhooks/clerk', express.raw({ type: 'application/json' }), async (req, res) => {
-  const webhookSecret = process.env.CLERK_WEBHOOK_SECRET!
-
-  const wh = new Webhook(webhookSecret)
-  let evt: any
-  try {
-    // Svix verifies using raw body bytes + svix headers
-    evt = wh.verify(req.body, {
-      'svix-id': req.headers['svix-id'] as string,
-      'svix-timestamp': req.headers['svix-timestamp'] as string,
-      'svix-signature': req.headers['svix-signature'] as string,
-    })
-  } catch (err) {
-    console.error('Webhook verification failed:', err)
-    return res.status(400).json({ error: 'Verification failed' })
-  }
-
-  if (evt.type === 'user.created') {
-    const { id, email_addresses, first_name, last_name } = evt.data
-    const email = email_addresses[0]?.email_address
-    const name = `${first_name ?? ''} ${last_name ?? ''}`.trim()
-    console.log(`New user: ${name} (${email})`)
-  }
-
-  if (evt.type === 'user.updated') {
-    const { id, email_addresses } = evt.data
-    const email = email_addresses[0]?.email_address
-    console.log(`User updated: ${id}, email: ${email}`)
-  }
-
-  if (evt.type === 'user.deleted') {
-    const { id } = evt.data
-    console.log(`User deleted: ${id}`)
-  }
-
-  // Return 200 status on success
-  return res.status(200).json({ received: true })
-})
+if (evt.type === 'user.created') {
+  // evt.data is now UserJSON, autocompletes id, email_addresses, etc.
+  console.log(evt.data.id)
+}
 ```
+
+For manual typing of nested payloads, import the JSON types from your framework's webhook subpath: `DeletedObjectJSON`, `EmailJSON`, `OrganizationInvitationJSON`, `OrganizationJSON`, `OrganizationMembershipJSON`, `SessionJSON`, `SMSMessageJSON`, `UserJSON`.
 
 ## Payload Field Reference
 
@@ -306,7 +283,7 @@ const {
 
 **User**: `user.created` `user.updated` `user.deleted`
 
-**Session**: `session.created` `session.ended` `session.pending` `session.removed` `session.revoked`
+**Session**: `session.created` `session.ended` `session.removed` `session.revoked`
 
 **Organization**: `organization.created` `organization.updated` `organization.deleted`
 
@@ -317,8 +294,6 @@ const {
 **Organization Invitation**: `organizationInvitation.accepted` `organizationInvitation.created` `organizationInvitation.revoked`
 
 **Communication**: `email.created` `sms.created`
-
-**Invitation**: `invitation.accepted` `invitation.created` `invitation.revoked`
 
 **Waitlist**: `waitlistEntry.created` `waitlistEntry.updated`
 
@@ -352,12 +327,19 @@ const {
 
 ## Testing & Deployment
 
-**Local**: Use ngrok to tunnel `localhost:3000` to internet. Add ngrok URL to Dashboard endpoint.
+**Local**: Tunnel `localhost:3000` to the internet so Clerk can reach the endpoint. Common options: `ngrok`, `localtunnel`, `Cloudflare Tunnel`. Add the public URL to the Dashboard endpoint.
 
-**Production**: Update webhook endpoint URL to production domain. Copy `CLERK_WEBHOOK_SECRET` to production env vars.
+**Production**: Update webhook endpoint URL to production domain. Copy `CLERK_WEBHOOK_SIGNING_SECRET` to production env vars.
+
+## References
+
+| Reference | Description |
+|-----------|-------------|
+| `references/frameworks.md` | Webhook handler examples for Express, Astro, Fastify, Nuxt, React Router, TanStack Start |
 
 ## See Also
 
 - `clerk-setup` - Initial Clerk install
 - `clerk-orgs` - Org membership events
+- `clerk-billing` - Subscription, subscription item, and payment attempt events
 - `clerk-backend-api` - Sync via direct API calls

--- a/skills/features/clerk-webhooks/evals/evals.json
+++ b/skills/features/clerk-webhooks/evals/evals.json
@@ -6,10 +6,10 @@
       "prompt": "every time a user signs up on our app i need to create a row in our users table in postgres (we use prisma). the table has id, email, name, clerkId, createdAt columns. can you set up the webhook handler? we're on next.js app router",
       "expected_output": "Creates webhook route handler at app/api/webhooks/route.ts, verifies webhook signature, handles user.created event, inserts into Prisma users table",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Creates route handler at app/api/webhooks/route.ts or similar path",
         "Uses POST method handler (not GET)",
-        "Includes webhook signature verification (verifyWebhook or svix verify)",
+        "Uses verifyWebhook from @clerk/nextjs/webhooks for signature verification",
         "Handles user.created event type and extracts email, name, id from payload",
         "Inserts into database using Prisma with the correct column mapping (clerkId = evt.data.id)",
         "Mentions that webhook route must be excluded from Clerk middleware (public route)"
@@ -20,7 +20,7 @@
       "prompt": "i want to send a welcome email via resend when someone creates an account. also want to notify our #new-users slack channel. we already have resend and slack sdks installed",
       "expected_output": "Webhook handler for user.created that sends welcome email via Resend and posts to Slack",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Listens for user.created webhook event",
         "Extracts user email and name from webhook payload",
         "Calls Resend API to send welcome email",
@@ -32,14 +32,14 @@
     {
       "id": 3,
       "prompt": "we're getting 401 errors on our webhook endpoint. the clerk dashboard shows the webhooks are being sent but our app keeps rejecting them. we're using express not next.js. heres our current code:\n\napp.post('/webhooks/clerk', express.json(), (req, res) => {\n  const evt = req.body;\n  console.log(evt);\n  res.json({ received: true });\n});",
-      "expected_output": "Identifies missing webhook verification, fixes express body parsing (needs raw body), adds proper Svix verification",
+      "expected_output": "Identifies missing webhook verification, fixes express body parsing (needs raw body), adds verifyWebhook from @clerk/express/webhooks",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Identifies that express.json() is wrong - needs raw body for signature verification",
-        "Shows express.raw() or express.text() instead of express.json() for the webhook route",
-        "Adds webhook signature verification using Svix or @clerk/express webhook utilities",
+        "Shows express.raw({ type: 'application/json' }) instead of express.json() for the webhook route",
+        "Uses verifyWebhook from @clerk/express/webhooks (not raw svix Webhook class)",
         "Preserves the existing route path /webhooks/clerk",
-        "Mentions CLERK_WEBHOOK_SECRET environment variable",
+        "Mentions CLERK_WEBHOOK_SIGNING_SECRET environment variable (not legacy CLERK_WEBHOOK_SECRET)",
         "Returns 200 status on success (not just res.json)"
       ]
     },
@@ -48,7 +48,7 @@
       "prompt": "our app has clerk organizations and we need to sync org membership changes to our database. when someone joins or leaves an org we need to update our team_members table. also when an org is created we need to create a workspace record",
       "expected_output": "Webhook handler for organizationMembership and organization events with database sync",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Handles organizationMembership.created event (user joins org)",
         "Handles organizationMembership.deleted event (user leaves org)",
         "Handles organization.created event (new org created)",

--- a/skills/features/clerk-webhooks/references/frameworks.md
+++ b/skills/features/clerk-webhooks/references/frameworks.md
@@ -1,0 +1,216 @@
+# Framework-Specific Webhook Handlers
+
+Each Clerk SDK package ships its own `verifyWebhook` adapter that reads the framework's native request type and uses `CLERK_WEBHOOK_SIGNING_SECRET` automatically. Use the framework-specific import; do not roll your own with raw `svix`.
+
+Same `WebhookEvent` payload shape across all frameworks. See SKILL.md for payload field reference and the full event catalog.
+
+## Express
+
+```typescript
+import { verifyWebhook } from '@clerk/express/webhooks'
+import express from 'express'
+
+const app = express()
+
+// Use express.raw() not express.json() for the webhook route -
+// signature verification requires the raw body bytes.
+app.post('/api/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
+  try {
+    const evt = await verifyWebhook(req)
+
+    if (evt.type === 'user.created') {
+      const { id, email_addresses, first_name, last_name } = evt.data
+      const email = email_addresses[0]?.email_address
+      console.log(`New user: ${first_name} ${last_name} (${email})`)
+    }
+
+    return res.send('Webhook received')
+  } catch (err) {
+    console.error('Error verifying webhook:', err)
+    return res.status(400).send('Error verifying webhook')
+  }
+})
+```
+
+## Astro
+
+```typescript
+// src/pages/api/webhooks.ts
+import { verifyWebhook } from '@clerk/astro/webhooks'
+import type { APIRoute } from 'astro'
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const evt = await verifyWebhook(request, {
+      signingSecret: import.meta.env.CLERK_WEBHOOK_SIGNING_SECRET,
+    })
+
+    if (evt.type === 'user.created') {
+      const { id, email_addresses } = evt.data
+      const email = email_addresses[0]?.email_address
+      console.log(`New user: ${id} (${email})`)
+    }
+
+    return new Response('Webhook received', { status: 200 })
+  } catch (err) {
+    console.error('Error verifying webhook:', err)
+    return new Response('Error verifying webhook', { status: 400 })
+  }
+}
+```
+
+Astro requires explicit `signingSecret` since `import.meta.env` is not auto-read.
+
+## Fastify
+
+```typescript
+import { verifyWebhook } from '@clerk/fastify/webhooks'
+import Fastify from 'fastify'
+
+const fastify = Fastify()
+
+fastify.post('/api/webhooks', async (request, reply) => {
+  try {
+    const evt = await verifyWebhook(request)
+
+    if (evt.type === 'user.created') {
+      const { id } = evt.data
+      console.log(`New user: ${id}`)
+    }
+
+    return 'Webhook received'
+  } catch (err) {
+    console.error('Error verifying webhook:', err)
+    return reply.code(400).send('Error verifying webhook')
+  }
+})
+```
+
+## Nuxt
+
+```typescript
+// server/api/webhooks.post.ts
+import { verifyWebhook } from '@clerk/nuxt/webhooks'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const evt = await verifyWebhook(event)
+
+    if (evt.type === 'user.created') {
+      const { id } = evt.data
+      console.log(`New user: ${id}`)
+    }
+
+    return 'Webhook received'
+  } catch (err) {
+    console.error('Error verifying webhook:', err)
+    setResponseStatus(event, 400)
+    return 'Error verifying webhook'
+  }
+})
+```
+
+Prefix the env var with `NUXT_` (i.e. `NUXT_CLERK_WEBHOOK_SIGNING_SECRET`) per Nuxt runtime config rules.
+
+When tunneling via ngrok in dev, allow the host in `nuxt.config.ts`:
+
+```typescript
+export default defineNuxtConfig({
+  vite: {
+    server: {
+      allowedHosts: ['fawn-two-nominally.ngrok-free.app'],
+    },
+  },
+})
+```
+
+## React Router
+
+```typescript
+// app/routes/webhooks.ts
+import { verifyWebhook } from '@clerk/react-router/webhooks'
+import type { Route } from './+types/webhooks'
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  try {
+    const evt = await verifyWebhook(request)
+
+    if (evt.type === 'user.created') {
+      const { id } = evt.data
+      console.log(`New user: ${id}`)
+    }
+
+    return new Response('Webhook received', { status: 200 })
+  } catch (err) {
+    console.error('Error verifying webhook:', err)
+    return new Response('Error verifying webhook', { status: 400 })
+  }
+}
+```
+
+Register the route in `router.ts`:
+
+```typescript
+import { type RouteConfig, route, index } from '@react-router/dev/routes'
+
+export default [
+  index('routes/home.tsx'),
+  route('api/webhooks', 'routes/webhooks.ts'),
+] satisfies RouteConfig
+```
+
+When tunneling via ngrok in dev, allow the host in `vite.config.ts`:
+
+```typescript
+export default defineConfig({
+  server: {
+    allowedHosts: ['fawn-two-nominally.ngrok-free.app'],
+  },
+})
+```
+
+## TanStack Start
+
+```typescript
+// app/routes/api/webhooks.ts
+import { verifyWebhook } from '@clerk/tanstack-react-start/webhooks'
+import { createServerFileRoute } from '@tanstack/react-start/server'
+
+export const ServerRoute = createServerFileRoute().methods({
+  POST: async ({ request }) => {
+    try {
+      const evt = await verifyWebhook(request)
+
+      if (evt.type === 'user.created') {
+        const { id } = evt.data
+        console.log(`New user: ${id}`)
+      }
+
+      return new Response('Webhook received', { status: 200 })
+    } catch (err) {
+      console.error('Error verifying webhook:', err)
+      return new Response('Error verifying webhook', { status: 400 })
+    }
+  },
+})
+```
+
+When tunneling via ngrok in dev, allow the host in `app.config.ts`:
+
+```typescript
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    allowedHosts: ['fawn-two-nominally.ngrok-free.app'],
+  },
+})
+```
+
+## Common Patterns Across Frameworks
+
+- All `verifyWebhook` adapters return the same `WebhookEvent` discriminated union, so handler logic (`if (evt.type === ...)`) is identical.
+- All adapters read `CLERK_WEBHOOK_SIGNING_SECRET` automatically except Astro (pass `signingSecret` option).
+- All adapters require a public webhook route, exclude `/api/webhooks(.*)` from middleware protection.
+- Vite-based frameworks (Nuxt, React Router, TanStack Start) need `allowedHosts` configured when tunneling localhost via ngrok in development.
+- Express specifically needs `express.raw({ type: 'application/json' })` for the webhook route, raw body bytes are required for signature verification.


### PR DESCRIPTION
Closes [AIE-917](https://linear.app/clerk/issue/AIE-917).

## Summary
- Switch examples to `verifyWebhook` from each framework's package; drop the raw svix path
- Update Core 3 middleware syntax (async `clerkMiddleware` with `await auth.protect()`)
- Use `CLERK_WEBHOOK_SIGNING_SECRET` env var consistently
- Add adapters for Astro, Fastify, Nuxt, React Router, TanStack Start in `references/frameworks.md` (was Next.js + Express only)
- Add type-narrowing guidance for the `WebhookEvent` discriminated union
- Add a "when to use webhooks" section covering eventual consistency and the sync-flow caveat
- Tighten event catalog to match SDK exports
- Migrate evals from `expectations` to `assertions` schema; align eval 3 with the modernized Express path

## Eval results

Ran the 4 evals locally with-skill vs baseline (no skill):

| Eval | Baseline | With skill |
|---|---|---|
| 1 Prisma user sync | 5/6 | 6/6 |
| 2 Resend + Slack | 6/6 | 6/6 |
| 3 Express 401 fix | 4/6 | 6/6 |
| 4 Org membership sync | 6/6 | 6/6 |
| **Total** | **21/24 (87.5%)** | **24/24 (100%)** |

Most discriminating: eval 3 (Express). Without the skill, the baseline reaches for raw `svix` and the legacy `CLERK_WEBHOOK_SECRET` env var, which is exactly what this PR steers away from.

Evals 2 and 4 don't change because the existing assertion is generic ("includes signature verification") and accepts raw svix. Worth tightening in a follow-up so the skill's modern-handler guidance is graded directly.

## Test plan
- [ ] Spot-check each framework adapter against the current docs
- [ ] Verify `evals/evals.json` parses against the agentskills.io schema
- [ ] Run a couple of evals against the updated skill and confirm they pass