### PR TITLE
refactor(nextjs-patterns): add compatibility, Show variants, middleware permission/token gating

### DIFF
--- a/skills/frameworks/clerk-nextjs-patterns/SKILL.md
+++ b/skills/frameworks/clerk-nextjs-patterns/SKILL.md
@@ -4,6 +4,7 @@ description: Advanced Next.js patterns - middleware, Server Actions, caching wit
   Clerk.
 license: MIT
 allowed-tools: WebFetch
+compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY. For manual JWT verification (standalone API servers without Clerk middleware), additionally requires CLERK_JWT_KEY or CLERK_PEM_PUBLIC_KEY.
 metadata:
   author: clerk
   version: 2.2.0
@@ -67,13 +68,47 @@ export default async function Page() {
 
 ### Conditional Rendering with `<Show>`
 
-For client-side conditional rendering based on auth state:
+For client-side conditional rendering based on auth state. `<Show>` covers both authentication checks and authorization (feature, plan, role, permission) in one component.
+
+**Authentication check:**
 
 ```tsx
 import { Show } from '@clerk/nextjs'
 
 <Show when="signed-in" fallback={<p>Please sign in</p>}>
   <Dashboard />
+</Show>
+```
+
+**Authorization checks (B2B):**
+
+```tsx
+// Feature-based (preferred — features can move between plans without redeploy)
+<Show when={{ feature: 'analytics' }} fallback={<UpgradePrompt />}>
+  <AnalyticsDashboard />
+</Show>
+
+// Permission-based (preferred over role-based for granular access)
+<Show when={{ permission: 'org:invoices:create' }}>
+  <NewInvoiceButton />
+</Show>
+
+// Plan-based (tier-level gating)
+<Show when={{ plan: 'pro' }}>
+  <ProFeatures />
+</Show>
+
+// Role-based (use sparingly — prefer permission)
+<Show when={{ role: 'org:admin' }}>
+  <AdminPanel />
+</Show>
+```
+
+**Callback for complex logic:**
+
+```tsx
+<Show when={(has) => has({ role: 'org:admin' }) || has({ role: 'org:billing_manager' })}>
+  <BillingActions />
 </Show>
 ```
 
@@ -206,8 +241,11 @@ Token sources:
 
 ## See Also
 
-- `clerk-setup`
-- `clerk-orgs`
+- `clerk-setup` - Initial Clerk install
+- `clerk-orgs` - B2B patterns (active org, role/permission gating)
+- `clerk-billing` - Plan and feature entitlements with `has()`
+- `clerk-webhooks` - Sync user/org events to your database
+- `clerk-custom-ui` - Theming and customization for built-in components
 
 ## Docs
 

--- a/skills/frameworks/clerk-nextjs-patterns/SKILL.md
+++ b/skills/frameworks/clerk-nextjs-patterns/SKILL.md
@@ -112,7 +112,7 @@ import { Show } from '@clerk/nextjs'
 </Show>
 ```
 
-> **Core 2 ONLY (skip if current SDK):** Use `<SignedIn>` and `<SignedOut>` components instead of `<Show>`. See `clerk-custom-ui` skill, `core-3/show-component.md` for the full migration table.
+> **Core 2 ONLY (skip if current SDK):** `<Show>` does not exist. For authentication, use `<SignedIn>` and `<SignedOut>`. For authorization (role / permission), use `<Protect>` with the same prop names (`role`, `permission`, `condition`). Feature- and plan-based variants require Core 3. See `clerk-custom-ui` skill, `core-3/show-component.md` for the full migration table.
 
 ## Common Pitfalls
 

--- a/skills/frameworks/clerk-nextjs-patterns/evals/evals.json
+++ b/skills/frameworks/clerk-nextjs-patterns/evals/evals.json
@@ -6,7 +6,7 @@
       "prompt": "my dashboard page uses useAuth and useUser hooks with useEffect for redirect. this causes a flash of unauthenticated content. convert it to a server component using auth() from @clerk/nextjs/server instead.",
       "expected_output": "Converts dashboard from client component with hooks to server component with auth(), removes useEffect redirect pattern",
       "scaffold": "nextjs-basic-auth",
-      "expectations": [
+      "assertions": [
         "Removes 'use client' directive from dashboard page",
         "Replaces useAuth/useUser hooks with auth() from @clerk/nextjs/server",
         "Uses server-side redirect() from next/navigation instead of useEffect + router.push",
@@ -19,7 +19,7 @@
       "prompt": "my api route at app/api/data/route.ts has no auth protection. anyone can access the data. add clerk auth to this api route so only authenticated users can get the data, and return 401 for unauthenticated requests.",
       "expected_output": "Adds auth() check to API route, returns 401 for unauthenticated requests",
       "scaffold": "nextjs-basic-auth",
-      "expectations": [
+      "assertions": [
         "Imports auth from @clerk/nextjs/server",
         "Calls auth() at the top of the GET handler",
         "Returns 401 status when userId is null",
@@ -30,12 +30,12 @@
     {
       "id": 3,
       "prompt": "my homepage is a client component that uses useUser to check if the user is signed in. convert it to use clerk's Show component pattern instead so it can be a server component with conditional rendering.",
-      "expected_output": "Converts home page to use SignedIn/SignedOut or Show components instead of useUser hook",
+      "expected_output": "Converts home page to use Show (preferred in Core 3) or SignedIn/SignedOut (Core 2) components instead of useUser hook",
       "scaffold": "nextjs-basic-auth",
-      "expectations": [
+      "assertions": [
         "Removes 'use client' directive from home page",
         "Removes useUser hook import and usage",
-        "Uses SignedIn/SignedOut components from @clerk/nextjs for conditional rendering",
+        "Uses Show with when='signed-in' (preferred) OR SignedIn/SignedOut components from @clerk/nextjs for conditional rendering",
         "Preserves the same visual output (welcome message when signed in, sign-in prompt when not)",
         "Page works as a server component"
       ]
@@ -45,7 +45,7 @@
       "prompt": "i need to protect all routes under /dashboard with clerk middleware instead of checking auth in each page component. update the middleware to use createRouteMatcher so only / and /sign-in are public.",
       "expected_output": "Updates middleware.ts to use createRouteMatcher with public routes, protecting /dashboard and all sub-routes",
       "scaffold": "nextjs-basic-auth",
-      "expectations": [
+      "assertions": [
         "Imports createRouteMatcher from @clerk/nextjs/server",
         "Defines public routes array including / and /sign-in",
         "Uses auth.protect() for non-public routes inside clerkMiddleware callback",
@@ -58,7 +58,7 @@
       "prompt": "i need to call an external API (Hasura GraphQL) from my Next.js server component. get a custom JWT using a template called 'hasura' and pass it in the Authorization header.",
       "expected_output": "Uses getToken with template parameter from auth() server-side, passes as Bearer token to external API",
       "scaffold": "nextjs-basic-auth",
-      "expectations": [
+      "assertions": [
         "Uses getToken with a template parameter (e.g. 'hasura') to get a custom JWT",
         "Uses either auth() server-side or useAuth() client-side to access getToken",
         "Passes the token as Authorization Bearer header to the external API call",
@@ -70,7 +70,7 @@
       "prompt": "i have a standalone Node.js API server that receives requests with a Clerk session token in the Authorization header. i need to verify the JWT signature and check if the user is authenticated. i don't want to use Clerk middleware, just manual verification.",
       "expected_output": "Manually verifies Clerk JWT using jsonwebtoken or @clerk/backend verifyToken, checks claims",
       "scaffold": "nextjs-basic-auth",
-      "expectations": [
+      "assertions": [
         "Extracts the token from the Authorization Bearer header",
         "Verifies the token using either jsonwebtoken with CLERK_PEM_PUBLIC_KEY or @clerk/backend verifyToken",
         "Checks token expiration (exp claim) and not-before (nbf claim)",

--- a/skills/frameworks/clerk-nextjs-patterns/references/api-routes.md
+++ b/skills/frameworks/clerk-nextjs-patterns/references/api-routes.md
@@ -1,4 +1,4 @@
-# API Routes (HIGH)
+# API Routes
 
 ## Auth Check Pattern
 

--- a/skills/frameworks/clerk-nextjs-patterns/references/caching-auth.md
+++ b/skills/frameworks/clerk-nextjs-patterns/references/caching-auth.md
@@ -1,4 +1,4 @@
-# Caching with Auth (CRITICAL)
+# Caching with Auth
 
 **CRITICAL**: Cache keys MUST include userId/orgId to prevent data leaking between users.
 

--- a/skills/frameworks/clerk-nextjs-patterns/references/middleware-strategies.md
+++ b/skills/frameworks/clerk-nextjs-patterns/references/middleware-strategies.md
@@ -70,6 +70,8 @@ export default clerkMiddleware(async (auth, req) => {
 
 Prefer permissions over roles — permissions are more granular and easier to reassign across roles in the Dashboard.
 
+> **Core 2 ONLY (skip if current SDK):** Middleware uses synchronous `clerkMiddleware((auth, req) => { auth().protect((has) => ...) })`. Note `auth()` is called as a function (not `auth.protect`) and the callback signature is the same.
+
 ## Token-Based Protection (Machine APIs)
 
 For routes that accept different token types (OAuth tokens, machine-to-machine tokens, API keys), pass a `token` option to `auth.protect()`:
@@ -85,6 +87,8 @@ export default clerkMiddleware(async (auth, req) => {
 ```
 
 Token types: `'session_token'` (default, browser sessions), `'oauth_token'`, `'api_key'`, `'m2m_token'`, `'any'` (accept any valid token).
+
+> **Core 2 ONLY (skip if current SDK):** Token-type protection requires Core 3. In Core 2, `auth().protect()` only accepts a callback (no `token` option) and only validates session tokens.
 
 ## Session Tasks
 

--- a/skills/frameworks/clerk-nextjs-patterns/references/middleware-strategies.md
+++ b/skills/frameworks/clerk-nextjs-patterns/references/middleware-strategies.md
@@ -1,4 +1,4 @@
-# Middleware Strategies (HIGH)
+# Middleware Strategies
 
 > **Filename:** `proxy.ts` (Next.js <=15: `middleware.ts`). The code is identical; only the filename changes.
 
@@ -45,6 +45,46 @@ export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) await auth.protect();
 });
 ```
+
+## Permission-Gated Routes
+
+For B2B apps where some routes require a specific permission or role, pass a callback to `auth.protect()`. Clerk returns a 404 if the check fails:
+
+```typescript
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+
+const isInvoiceRoute = createRouteMatcher(['/invoices(.*)']);
+const isAdminRoute = createRouteMatcher(['/admin(.*)']);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isInvoiceRoute(req)) {
+    await auth.protect((has) => has({ permission: 'org:invoices:create' }));
+  }
+  if (isAdminRoute(req)) {
+    await auth.protect((has) =>
+      has({ role: 'org:admin' }) || has({ role: 'org:billing_manager' })
+    );
+  }
+});
+```
+
+Prefer permissions over roles — permissions are more granular and easier to reassign across roles in the Dashboard.
+
+## Token-Based Protection (Machine APIs)
+
+For routes that accept different token types (OAuth tokens, machine-to-machine tokens, API keys), pass a `token` option to `auth.protect()`:
+
+```typescript
+const isMachineApi = createRouteMatcher(['/api/machine(.*)']);
+const isPublicApi = createRouteMatcher(['/api/public(.*)']);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isMachineApi(req)) await auth.protect({ token: 'm2m_token' });
+  if (isPublicApi(req)) await auth.protect({ token: 'any' });
+});
+```
+
+Token types: `'session_token'` (default, browser sessions), `'oauth_token'`, `'api_key'`, `'m2m_token'`, `'any'` (accept any valid token).
 
 ## Session Tasks
 

--- a/skills/frameworks/clerk-nextjs-patterns/references/server-actions.md
+++ b/skills/frameworks/clerk-nextjs-patterns/references/server-actions.md
@@ -1,4 +1,4 @@
-# Server Actions (HIGH)
+# Server Actions
 
 Server Actions are public endpoints. Always verify auth.
 

--- a/skills/frameworks/clerk-nextjs-patterns/references/server-vs-client.md
+++ b/skills/frameworks/clerk-nextjs-patterns/references/server-vs-client.md
@@ -1,4 +1,4 @@
-# Server vs Client (CRITICAL)
+# Server vs Client
 
 ## CRITICAL: Always `await auth()`
 


### PR DESCRIPTION
Closes [AIE-920](https://linear.app/clerk/issue/AIE-920).

## Summary
- Add top-level `compatibility:` field listing required env vars
- Migrate evals from legacy `expectations` to `assertions` schema; loosen eval 3 to accept `<Show>` (preferred in Core 3) or `<SignedIn>`/`<SignedOut>` (Core 2)
- Remove severity-tag suffixes from reference headers (`(HIGH)`, `(CRITICAL)`)
- Expand the `<Show>` section in `SKILL.md` with authorization variants: `when={{ feature }}`, `when={{ permission }}`, `when={{ plan }}`, `when={{ role }}`, plus the callback form
- Add Permission-Gated Routes section to `references/middleware-strategies.md` using `auth.protect((has) => ...)`
- Add Token-Based Protection section covering `auth.protect({ token })` for machine API auth (`m2m_token`, `oauth_token`, `api_key`, `session_token`, `any`)
- Expand See Also with `clerk-billing`, `clerk-webhooks`, `clerk-custom-ui`

## Test plan
- [ ] Verify `evals/evals.json` parses against the agentskills.io schema
- [ ] Spot-check `auth.protect()` callback signature against current docs
- [ ] Run a couple of evals against the updated skill and confirm they pass