### PR TITLE
refactor(setup): drop Remix, modernize Dashboard URLs + Keyless wording

### DIFF
--- a/skills/core/clerk-setup/SKILL.md
+++ b/skills/core/clerk-setup/SKILL.md
@@ -4,6 +4,7 @@ description: Add Clerk authentication to any project by following the official q
   guides.
 license: MIT
 allowed-tools: WebFetch
+compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY (or framework-specific equivalents like VITE_CLERK_PUBLISHABLE_KEY for Vite-based apps). Keys can be auto-generated via Keyless on first SDK initialization, or pulled from the Clerk Dashboard. Requires Node.js 20.9.0 or higher.
 metadata:
   author: clerk
   version: 2.3.0
@@ -22,7 +23,7 @@ This skill sets up Clerk for authentication by following the official quickstart
 | 1. Detect framework | Check `package.json` dependencies |
 | 2. Fetch quickstart | Use WebFetch on the appropriate docs URL |
 | 3. Follow instructions | Execute steps; create `proxy.ts` (Next.js <=15: `middleware.ts`) |
-| 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) |
+| 4. Get API keys | From [dashboard.clerk.com](https://dashboard.clerk.com/~/api-keys) |
 
 > If the project has `components.json` (shadcn/ui), apply the shadcn theme after setup. See `clerk-custom-ui` skill → shadcn Theme.
 
@@ -33,10 +34,10 @@ Check `package.json` to identify the framework:
 | Dependency | Framework | Quickstart URL |
 |------------|-----------|----------------|
 | `next` | Next.js | `https://clerk.com/docs/nextjs/getting-started/quickstart` |
-| `@remix-run/react` | Remix | `https://clerk.com/docs/remix/getting-started/quickstart` |
+| `@remix-run/react` | Remix (deprecated) | Migrate to React Router v7 — use the React Router quickstart below |
+| `react-router` | React Router (v7+) | `https://clerk.com/docs/react-router/getting-started/quickstart` |
 | `astro` | Astro | `https://clerk.com/docs/astro/getting-started/quickstart` |
 | `nuxt` | Nuxt | `https://clerk.com/docs/nuxt/getting-started/quickstart` |
-| `react-router` | React Router | `https://clerk.com/docs/react-router/getting-started/quickstart` |
 | `@tanstack/react-start` | TanStack Start | `https://clerk.com/docs/tanstack-react-start/getting-started/quickstart` |
 | `react` (no framework) | React SPA | `https://clerk.com/docs/react/getting-started/quickstart` |
 | `vue` | Vue | `https://clerk.com/docs/vue/getting-started/quickstart` |
@@ -100,12 +101,13 @@ Execute each step from the quickstart guide:
 Two paths for development API keys:
 
 **Keyless (Automatic)**
-- On first SDK initialization, Clerk auto-generates dev keys and shows "Claim your application" popover
-- No manual key setup required—keys are created and injected automatically
+- On first SDK initialization, Clerk auto-generates dev keys and shows a "Configure your application" button in the bottom right of the running app
+- No manual key setup required, keys are created and injected automatically
+- Selecting "Configure your application" associates the auto-generated app with your Clerk account so you can edit it from the Dashboard
 - Simplest path for new projects
 
 **Manual (Dashboard)**
-- Get keys from [dashboard.clerk.com](https://dashboard.clerk.com/last-active?path=api-keys) if Keyless doesn't trigger
+- Get keys from [dashboard.clerk.com](https://dashboard.clerk.com/~/api-keys) if Keyless doesn't trigger
 - **Publishable Key**: Starts with `pk_test_` or `pk_live_`
 - **Secret Key**: Starts with `sk_test_` or `sk_live_`
 - Set as environment variables: `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`
@@ -229,16 +231,16 @@ Also import the shadcn CSS in your global styles:
 
 ## Common Pitfalls
 
-| Level | Issue | Solution |
-|-------|-------|----------|
-| CRITICAL | Missing `await` on `auth()` | In Next.js 15+, `auth()` is async: `const { userId } = await auth()` |
-| CRITICAL | Exposing `CLERK_SECRET_KEY` | Never use secret key in client code; only `NEXT_PUBLIC_*` keys are safe |
-| HIGH | Missing middleware matcher | Include API routes: `matcher: ['/((?!.*\\..*|_next).*)', '/']` |
-| HIGH | ClerkProvider placement | Must be inside `<body>` in root layout (Core 2: could wrap `<html>`) |
-| HIGH | Auth routes not public | Allow `/sign-in`, `/sign-up` in middleware config |
-| HIGH | Landing page requires auth | To keep "/" public, exclude it: `matcher: ['/((?!.*\\..*|_next|^/$).*)', '/api/(.*)']` |
-| MEDIUM | Wrong import path | Server code uses `@clerk/nextjs/server`, client uses `@clerk/nextjs` |
-| MEDIUM | Wrong package name | Use `@clerk/react` not `@clerk/clerk-react` (Core 2 naming) |
+| Issue | Solution |
+|-------|----------|
+| Missing `await` on `auth()` | In Next.js 15+, `auth()` is async: `const { userId } = await auth()` |
+| Exposing `CLERK_SECRET_KEY` | Never use the secret key in client code; only `NEXT_PUBLIC_*` keys are safe |
+| Missing middleware matcher | Include API routes: `matcher: ['/((?!.*\\..*|_next).*)', '/']` |
+| ClerkProvider placement | Must be inside `<body>` in root layout (Core 2: could wrap `<html>`) |
+| Auth routes not public | Allow `/sign-in`, `/sign-up` in middleware config |
+| Landing page requires auth | To keep "/" public, exclude it: `matcher: ['/((?!.*\\..*|_next|^/$).*)', '/api/(.*)']` |
+| Wrong import path | Server code uses `@clerk/nextjs/server`, client uses `@clerk/nextjs` |
+| Wrong package name | Use `@clerk/react` not `@clerk/clerk-react` (Core 2 naming) |
 
 ## See Also
 

--- a/skills/core/clerk-setup/SKILL.md
+++ b/skills/core/clerk-setup/SKILL.md
@@ -14,9 +14,66 @@ metadata:
 
 > **Version**: Check `package.json` for the SDK version — see `clerk` skill for the version table. Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts.
 
-This skill sets up Clerk for authentication by following the official quickstart documentation.
+This skill sets up Clerk for authentication by following the official quickstart documentation. For agents, the `clerk` CLI handles most of this end to end — see the next section.
 
-## Quick Reference
+## Agent-first: Provision via CLI
+
+The `clerk` CLI replaces most Dashboard clicks. Three scenarios cover almost everything:
+
+### Scenario A — New project, new Clerk app
+
+```bash
+clerk init --framework <next|react|vue|nuxt|astro|react-router|tanstack-react-start|expressjs|fastify|expo> -y
+```
+
+`clerk init` creates the Clerk app via PLAPI, links the project, writes the framework-specific publishable + secret keys to the right env file (e.g. `.env.local` for Next.js, `.env` for Vite-based projects), and installs the SDK package.
+
+### Scenario B — Existing project, existing Clerk app
+
+```bash
+clerk auth login                      # one-time OAuth (skip if already logged in)
+clerk link                            # autolinks if a CLERK_PUBLISHABLE_KEY is in your .env
+clerk link --app app_xxx              # explicit form, required in agent mode
+clerk env pull                        # writes the framework-detected env vars
+```
+
+### Scenario C — Existing project, new Clerk app
+
+```bash
+clerk auth login
+clerk apps create "My App" --json     # returns the new app_id
+clerk link --app app_xxx
+clerk env pull
+```
+
+### Daily ops
+
+```bash
+clerk env pull                        # refresh keys (uses linked profile)
+clerk env pull --instance prod        # production keys
+clerk doctor --json                   # framework integration health check
+```
+
+### Rotate the secret key (replaces Dashboard rotation)
+
+PLAPI exposes secret-key rotation directly. Use raw `clerk api` until the friendly wrapper ships:
+
+```bash
+clerk api --platform POST /v1/platform/applications/<app_id>/rotate_secret_keys \
+  -d '{"delay_old_secrets_expiration_hours": 24, "reason": "scheduled rotation"}'
+```
+
+`delay_old_secrets_expiration_hours` keeps the old key valid for the grace period so deploys can roll forward without downtime.
+
+### Notes for agents
+
+- `clerk link` (no flags) only autolinks when a `CLERK_PUBLISHABLE_KEY` is already in `.env` / `.env.local`. Without it, agent mode errors out: "Cannot select an application in agent mode." When that happens, run `clerk apps list --json`, and ask the user which `app_id` to link rather than guessing.
+- Pass `--json` on `apps list/create`, `users create`, and `doctor` for parseable output.
+- The CLI auto-detects framework env var names (`VITE_CLERK_PUBLISHABLE_KEY` for Vite, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` for Next.js, etc.) and target file (`.env.development.local` > `.env.local` > `.env`).
+
+## Quick Reference (Dashboard fallback)
+
+If the CLI isn't an option (sandboxed environments, docs walkthroughs), here's the manual Dashboard path:
 
 | Step | Action |
 |------|--------|
@@ -230,6 +287,8 @@ Also import the shadcn CSS in your global styles:
 > **Core 2 ONLY (skip if current SDK):** Import from `@clerk/themes` and `@clerk/themes/shadcn.css` instead.
 
 ## Common Pitfalls
+
+> **Run `clerk doctor` first.** It checks framework integration, env vars, middleware presence, and SDK install status. Fixes a lot of these in one shot.
 
 | Issue | Solution |
 |-------|----------|


### PR DESCRIPTION
Closes [AIE-922](https://linear.app/clerk/issue/AIE-922).

## Summary
- Add top-level `compatibility:` field listing required env vars and Node.js version
- Drop deprecated Remix entry from framework detection table (Remix → React Router v7)
- Modernize Dashboard URLs: `dashboard.clerk.com/last-active?path=api-keys` → `dashboard.clerk.com/~/api-keys`
- Update Keyless wording to match current quickstart UX ("Configure your application" button)
- Remove severity-tag column (`CRITICAL` / `HIGH` / `MEDIUM`) from Common Pitfalls table; keep symptom + solution

## Test plan
- [ ] Verify each quickstart URL still 200s (all 14 verified during audit; only Remix was 404)
- [ ] Confirm `dashboard.clerk.com/~/api-keys` resolves correctly
- [ ] Spot-check Keyless flow against the current Next.js quickstart