### PR TITLE
feat(billing): add agent-first CLI sidebar for programmatic billing config

### DIFF
--- a/skills/features/clerk-billing/SKILL.md
+++ b/skills/features/clerk-billing/SKILL.md
@@ -87,9 +87,8 @@ clerk api --platform PATCH /v1/platform/applications/<app_id>/instances/<ins_id>
 
 ### Notes
 
-- This handles **billing config** (toggles + plans + features catalog). **Subscription lifecycle** (users picking a plan, checkout, renewal, cancellation) still flows through `<PricingTable />` + billing webhooks — `clerk-webhooks` skill covers the lifecycle events.
+- This handles **billing config** (toggles + plans + features catalog). **Subscription lifecycle** (users picking a plan, checkout, renewal, cancellation) still flows through `<PricingTable />` + billing webhooks, see `clerk-webhooks` skill for the lifecycle events.
 - Top-level `features` map manipulation and plan-feature attachments (sync) are fully supported via the PLAPI billing config handler.
-- When the friendly `clerk billing` namespace ships ([AIE-823](https://linear.app/clerk/issue/AIE-823)), the raw `clerk api` examples above will swap to ergonomic wrappers.
 
 ## What Do You Need?
 

--- a/skills/features/clerk-billing/SKILL.md
+++ b/skills/features/clerk-billing/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # Billing
 
-> **STOP, Dashboard-only prerequisite.** Billing must be enabled from the Clerk Dashboard before any `<PricingTable />`, `<CheckoutButton />`, `has({ plan })`, or `has({ feature })` usage works. The Clerk CLI and Backend API do **not** expose a toggle for this today, the only path is [dashboard.clerk.com → your app → Billing → Settings](https://dashboard.clerk.com/last-active?path=billing/settings). Dev instances can use the shared Clerk development gateway (no Stripe account needed); production requires a Stripe account for payment processing only.
+> **STOP, Dashboard-only prerequisite.** Billing must be enabled from the Clerk Dashboard before any `<PricingTable />`, `<CheckoutButton />`, `has({ plan })`, or `has({ feature })` usage works. The Enable Billing toggle is Dashboard-only today, the only path is [dashboard.clerk.com → your app → Billing → Settings](https://dashboard.clerk.com/last-active?path=billing/settings). Dev instances can use the shared Clerk development gateway (no Stripe account needed); production requires a Stripe account for payment processing only. Once enabled, plan and feature configuration can be edited via the CLI, see "Agent-first: Programmatic billing config" below.
 >
 > **Note**: Billing APIs are still experimental. Pin your `@clerk/nextjs` and `clerk-js` package versions. See `clerk` skill for the supported version table.
 
@@ -40,6 +40,46 @@ metadata:
 | Create / edit plans | `https://dashboard.clerk.com/last-active?path=billing/plans` |
 | Membership mode (B2C + B2B coexistence) | `https://dashboard.clerk.com/last-active?path=organizations-settings` |
 | Edit features | Plans → click a plan → Features section (no direct URL) |
+
+## Agent-first: Programmatic billing config
+
+Plans and features live in the instance config and can be edited via PLAPI without touching the Dashboard. Useful for agents seeding plans, replicating config across instances, or version-controlling billing structure.
+
+Pre-req: project linked to the Clerk app (`clerk auth login` + `clerk link`, see `clerk-setup`).
+
+### Pull current billing config
+
+```bash
+clerk config pull --keys billing > billing.json
+```
+
+This writes the current billing config (plans + features) for the linked instance to `billing.json`.
+
+### Edit and apply
+
+Edit `billing.json` to add/remove plans or features, then preview the diff and apply:
+
+```bash
+clerk config patch --file billing.json --dry-run
+clerk config patch --file billing.json
+```
+
+Pass `--instance prod` to target the production instance instead of dev.
+
+### Raw PATCH (full control)
+
+For one-shot updates without a config file:
+
+```bash
+clerk api --platform PATCH /v1/platform/applications/<app_id>/instances/<ins_id>/config \
+  -d '{"billing":{"plans":[{"slug":"pro","name":"Pro","amount":2000,"period":"month"}]}}'
+```
+
+### Notes
+
+- **Enable Billing toggle** (the instance-level on/off switch) is still Dashboard-only today — `clerk config patch` can edit plan/feature structure but cannot flip the master toggle.
+- This handles **billing config** (the catalog of plans + features). **Subscription lifecycle** (users picking a plan, checkout, renewal, cancellation) still flows through `<PricingTable />` + billing webhooks — `clerk-webhooks` skill covers the lifecycle events.
+- When the friendly `clerk billing` namespace ships ([AIE-823](https://linear.app/clerk/issue/AIE-823)), the raw `clerk api` examples above will swap to ergonomic wrappers.
 
 ## What Do You Need?
 

--- a/skills/features/clerk-billing/SKILL.md
+++ b/skills/features/clerk-billing/SKILL.md
@@ -15,13 +15,13 @@ metadata:
 
 # Billing
 
-> **STOP, Dashboard-only prerequisite.** Billing must be enabled from the Clerk Dashboard before any `<PricingTable />`, `<CheckoutButton />`, `has({ plan })`, or `has({ feature })` usage works. The Enable Billing toggle is Dashboard-only today, the only path is [dashboard.clerk.com → your app → Billing → Settings](https://dashboard.clerk.com/last-active?path=billing/settings). Dev instances can use the shared Clerk development gateway (no Stripe account needed); production requires a Stripe account for payment processing only. Once enabled, plan and feature configuration can be edited via the CLI, see "Agent-first: Programmatic billing config" below.
+> **STOP, prerequisite.** Billing must be enabled before any `<PricingTable />`, `<CheckoutButton />`, `has({ plan })`, or `has({ feature })` usage works. Two paths: (1) [Dashboard → Billing → Settings](https://dashboard.clerk.com/last-active?path=billing/settings), or (2) `clerk config patch` with `billing.user_enabled` / `billing.organization_enabled` (see "Agent-first: Programmatic billing config" below). Enabling auto-creates default `free_user` / `free_org` plans. Dev instances can use the shared Clerk development gateway (no Stripe account needed); production requires a Stripe account for payment processing only.
 >
 > **Note**: Billing APIs are still experimental. Pin your `@clerk/nextjs` and `clerk-js` package versions. See `clerk` skill for the supported version table.
 
 ## Quick Start
 
-1. **Enable Billing**, [Dashboard → Billing → Settings](https://dashboard.clerk.com/last-active?path=billing/settings). Dashboard-only; no CLI or API path. Skipping this throws `cannot_render_billing_disabled` in dev and renders empty in prod.
+1. **Enable Billing**, via [Dashboard → Billing → Settings](https://dashboard.clerk.com/last-active?path=billing/settings) or `clerk config patch` (see Agent-first section). Skipping this throws `cannot_render_billing_disabled` in dev and renders empty in prod.
 2. **Create plans in the matching tab**, [Dashboard → Billing → Plans](https://dashboard.clerk.com/last-active?path=billing/plans). Two tabs, slugs scoped per tab, not movable after creation:
    - **User Plans** → `<PricingTable />` (default `for="user"`)
    - **Organization Plans** → `<PricingTable for="organization" />`
@@ -43,9 +43,19 @@ metadata:
 
 ## Agent-first: Programmatic billing config
 
-Plans and features live in the instance config and can be edited via PLAPI without touching the Dashboard. Useful for agents seeding plans, replicating config across instances, or version-controlling billing structure.
+The full billing config (enable toggles, plans, features, plan-feature attachments) is editable via PLAPI without touching the Dashboard. Useful for agents seeding plans, replicating config across instances, or version-controlling billing structure.
 
 Pre-req: project linked to the Clerk app (`clerk auth login` + `clerk link`, see `clerk-setup`).
+
+### Enable Billing via CLI
+
+The Enable Billing toggle is writable via `clerk config patch`:
+
+```bash
+# Enable billing for users + orgs in one PATCH (auto-creates free_user and free_org plans):
+clerk api --platform PATCH /v1/platform/applications/<app_id>/instances/<ins_id>/config \
+  -d '{"billing":{"user_enabled":true,"organization_enabled":true}}'
+```
 
 ### Pull current billing config
 
@@ -53,7 +63,7 @@ Pre-req: project linked to the Clerk app (`clerk auth login` + `clerk link`, see
 clerk config pull --keys billing > billing.json
 ```
 
-This writes the current billing config (plans + features) for the linked instance to `billing.json`.
+This writes the current billing config (toggles + plans + features) for the linked instance to `billing.json`.
 
 ### Edit and apply
 
@@ -68,17 +78,17 @@ Pass `--instance prod` to target the production instance instead of dev.
 
 ### Raw PATCH (full control)
 
-For one-shot updates without a config file:
+For one-shot plan/feature updates without a config file:
 
 ```bash
 clerk api --platform PATCH /v1/platform/applications/<app_id>/instances/<ins_id>/config \
-  -d '{"billing":{"plans":[{"slug":"pro","name":"Pro","amount":2000,"period":"month"}]}}'
+  -d '{"billing":{"plans":[{"slug":"pro","name":"Pro","amount":2000,"currency":"usd","payer_type":"user","is_recurring":true}],"features":[{"slug":"export","name":"Export"}]}}'
 ```
 
 ### Notes
 
-- **Enable Billing toggle** (the instance-level on/off switch) is still Dashboard-only today — `clerk config patch` can edit plan/feature structure but cannot flip the master toggle.
-- This handles **billing config** (the catalog of plans + features). **Subscription lifecycle** (users picking a plan, checkout, renewal, cancellation) still flows through `<PricingTable />` + billing webhooks — `clerk-webhooks` skill covers the lifecycle events.
+- This handles **billing config** (toggles + plans + features catalog). **Subscription lifecycle** (users picking a plan, checkout, renewal, cancellation) still flows through `<PricingTable />` + billing webhooks — `clerk-webhooks` skill covers the lifecycle events.
+- Top-level `features` map manipulation and plan-feature attachments (sync) are fully supported via the PLAPI billing config handler.
 - When the friendly `clerk billing` namespace ships ([AIE-823](https://linear.app/clerk/issue/AIE-823)), the raw `clerk api` examples above will swap to ergonomic wrappers.
 
 ## What Do You Need?

--- a/skills/features/clerk-billing/references/b2b-patterns.md
+++ b/skills/features/clerk-billing/references/b2b-patterns.md
@@ -4,7 +4,7 @@
 
 B2B billing in Clerk attaches subscriptions to **organizations**, not individual users. Each org gets its own subscription. Plans can carry a **seat limit** (membership cap) which Clerk enforces on member invites.
 
-> **Plans must be created as Organization Plans, not User Plans.** Slugs are scoped per type. A `team` plan registered as a User Plan will not appear in `<PricingTable for="organization" />`, and vice versa. Plan type cannot be changed after creation, recreate if misplaced.
+> **Create the plan as an Organization Plan, not a User Plan.** Use [Dashboard → Billing → Plans](https://dashboard.clerk.com/last-active?path=billing/plans) (Organization Plans tab) or `clerk config patch` with `billing.plans`. Slugs are scoped per type. A `team` plan registered under User Plans will not appear in `<PricingTable for="organization" />`, and vice versa. Plan type cannot be changed after creation, recreate if misplaced.
 
 ## Core Pattern: Org-Level Plan Check
 
@@ -36,7 +36,7 @@ Clerk Billing's B2B model is **seat-limit plans**: each organization plan has a 
 Key invariants:
 - **Fixed price per plan**, not auto-scaling per member. Adding members does not increment the org's billing amount on the active plan.
 - **One `active` SubscriptionItem per payer per Plan.** Do not derive seat count from `items.length`.
-- **Seat limit is a Plan property.** Set it when creating the plan; it cannot be changed later.
+- **Seat limit is a Plan property.** Set it when creating the plan (Dashboard → Billing → Plans → Organization Plans tab, or `clerk config patch`); it cannot be changed later.
 - When an org exceeds or changes to a plan with a lower limit, existing members stay but new invites are blocked until the org is under cap. See [Plans with seat limits](https://clerk.com/docs/guides/billing/seat-limit-plans) for the exact admin behavior.
 
 No custom seat-counting code is needed. Read the active plan with `has({ plan: 'org:team' })` and let Clerk enforce membership limits.
@@ -100,7 +100,7 @@ Tier plans by seat cap so bigger orgs pay more:
 | Business | `org:business` | 25 |
 | Enterprise | `org:enterprise` | unlimited (requires B2B Authentication add-on) |
 
-Define these as **Organization Plans** with **Seat-based** pricing enabled. Use the `org:` prefix in slugs to disambiguate org plans from user plans in code (`has({ plan: 'org:team' })` vs `has({ plan: 'team' })`). Seat caps above 20 and "unlimited" require the B2B Authentication add-on.
+Define these via Dashboard → Billing → Plans → **Organization Plans** tab with **Seat-based** toggled on, or via `clerk config patch` with `billing.plans`. Use the `org:` prefix in slugs to disambiguate org plans from user plans in code (`has({ plan: 'org:team' })` vs `has({ plan: 'team' })`). Seat caps above 20 and "unlimited" require the B2B Authentication add-on.
 
 ## Common Mistake: Checking Plan Without Active Org
 

--- a/skills/features/clerk-billing/references/b2b-patterns.md
+++ b/skills/features/clerk-billing/references/b2b-patterns.md
@@ -4,7 +4,7 @@
 
 B2B billing in Clerk attaches subscriptions to **organizations**, not individual users. Each org gets its own subscription. Plans can carry a **seat limit** (membership cap) which Clerk enforces on member invites.
 
-> **Create the plan in the Organization Plans tab.** [Dashboard → Billing → Plans](https://dashboard.clerk.com/last-active?path=billing/plans) has two tabs; slugs are scoped per tab. A `team` plan created under *User Plans* will not appear in `<PricingTable for="organization" />`, and vice versa. Plans cannot be moved between tabs, recreate if misplaced.
+> **Create the plan in the Organization Plans tab.** [Dashboard → Billing → Plans](https://dashboard.clerk.com/last-active?path=billing/plans) has two tabs; slugs are scoped per tab. A `team` plan created under *User Plans* will not appear in `<PricingTable for="organization" />`, and vice versa. Plans cannot be moved between tabs, recreate if misplaced. (Plans are also creatable via `clerk config patch`, see SKILL.md → Agent-first.)
 
 ## Core Pattern: Org-Level Plan Check
 
@@ -36,7 +36,7 @@ Clerk Billing's B2B model is **seat-limit plans**: each organization plan has a 
 Key invariants:
 - **Fixed price per plan**, not auto-scaling per member. Adding members does not increment the org's billing amount on the active plan.
 - **One `active` SubscriptionItem per payer per Plan.** Do not derive seat count from `items.length`.
-- **Seat limit is a Plan property.** Set it when creating the plan in Dashboard → Billing → Plans (Organization Plans tab); it cannot be changed later.
+- **Seat limit is a Plan property.** Set it when creating the plan (Dashboard → Billing → Plans → Organization Plans tab, or via `clerk config patch`); it cannot be changed later.
 - When an org exceeds or changes to a plan with a lower limit, existing members stay but new invites are blocked until the org is under cap. See [Plans with seat limits](https://clerk.com/docs/guides/billing/seat-limit-plans) for the exact admin behavior.
 
 No custom seat-counting code is needed. Read the active plan with `has({ plan: 'org:team' })` and let Clerk enforce membership limits.
@@ -100,7 +100,7 @@ Tier plans by seat cap so bigger orgs pay more:
 | Business | `org:business` | 25 |
 | Enterprise | `org:enterprise` | unlimited (requires B2B Authentication add-on) |
 
-Define these in Clerk Dashboard → Billing → Plans → **Organization Plans** tab, toggle **Seat-based** on when creating. Use the `org:` prefix in slugs to disambiguate org plans from user plans in code (`has({ plan: 'org:team' })` vs `has({ plan: 'team' })`). Seat caps above 20 and "unlimited" require the B2B Authentication add-on.
+Define these in Clerk Dashboard → Billing → Plans → **Organization Plans** tab (or via `clerk config patch`, see SKILL.md → Agent-first), toggle **Seat-based** on when creating. Use the `org:` prefix in slugs to disambiguate org plans from user plans in code (`has({ plan: 'org:team' })` vs `has({ plan: 'team' })`). Seat caps above 20 and "unlimited" require the B2B Authentication add-on.
 
 ## Common Mistake: Checking Plan Without Active Org
 

--- a/skills/features/clerk-billing/references/b2b-patterns.md
+++ b/skills/features/clerk-billing/references/b2b-patterns.md
@@ -4,7 +4,7 @@
 
 B2B billing in Clerk attaches subscriptions to **organizations**, not individual users. Each org gets its own subscription. Plans can carry a **seat limit** (membership cap) which Clerk enforces on member invites.
 
-> **Create the plan in the Organization Plans tab.** [Dashboard → Billing → Plans](https://dashboard.clerk.com/last-active?path=billing/plans) has two tabs; slugs are scoped per tab. A `team` plan created under *User Plans* will not appear in `<PricingTable for="organization" />`, and vice versa. Plans cannot be moved between tabs, recreate if misplaced. (Plans are also creatable via `clerk config patch`, see SKILL.md → Agent-first.)
+> **Plans must be created as Organization Plans, not User Plans.** Slugs are scoped per type. A `team` plan registered as a User Plan will not appear in `<PricingTable for="organization" />`, and vice versa. Plan type cannot be changed after creation, recreate if misplaced.
 
 ## Core Pattern: Org-Level Plan Check
 
@@ -36,7 +36,7 @@ Clerk Billing's B2B model is **seat-limit plans**: each organization plan has a 
 Key invariants:
 - **Fixed price per plan**, not auto-scaling per member. Adding members does not increment the org's billing amount on the active plan.
 - **One `active` SubscriptionItem per payer per Plan.** Do not derive seat count from `items.length`.
-- **Seat limit is a Plan property.** Set it when creating the plan (Dashboard → Billing → Plans → Organization Plans tab, or via `clerk config patch`); it cannot be changed later.
+- **Seat limit is a Plan property.** Set it when creating the plan; it cannot be changed later.
 - When an org exceeds or changes to a plan with a lower limit, existing members stay but new invites are blocked until the org is under cap. See [Plans with seat limits](https://clerk.com/docs/guides/billing/seat-limit-plans) for the exact admin behavior.
 
 No custom seat-counting code is needed. Read the active plan with `has({ plan: 'org:team' })` and let Clerk enforce membership limits.
@@ -100,7 +100,7 @@ Tier plans by seat cap so bigger orgs pay more:
 | Business | `org:business` | 25 |
 | Enterprise | `org:enterprise` | unlimited (requires B2B Authentication add-on) |
 
-Define these in Clerk Dashboard → Billing → Plans → **Organization Plans** tab (or via `clerk config patch`, see SKILL.md → Agent-first), toggle **Seat-based** on when creating. Use the `org:` prefix in slugs to disambiguate org plans from user plans in code (`has({ plan: 'org:team' })` vs `has({ plan: 'team' })`). Seat caps above 20 and "unlimited" require the B2B Authentication add-on.
+Define these as **Organization Plans** with **Seat-based** pricing enabled. Use the `org:` prefix in slugs to disambiguate org plans from user plans in code (`has({ plan: 'org:team' })` vs `has({ plan: 'team' })`). Seat caps above 20 and "unlimited" require the B2B Authentication add-on.
 
 ## Common Mistake: Checking Plan Without Active Org
 

--- a/skills/features/clerk-billing/references/b2c-patterns.md
+++ b/skills/features/clerk-billing/references/b2c-patterns.md
@@ -6,7 +6,7 @@ B2C billing in Clerk attaches subscriptions to **individual users**. Each user g
 
 > **Prerequisite: personal accounts must be allowed.** If Organizations are enabled, open [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) and set **Membership options → "Membership optional"**. In "Membership required" mode personal accounts are disabled, `<PricingTable />` silently excludes any user without an active org (no error, no console warning). Check this first when a user reports "subscribe does nothing."
 
-Plans for B2C must be created under the **User Plans** tab in Dashboard → Billing → Plans (or via `clerk config patch`, see SKILL.md → Agent-first). A `pro` plan under *Organization Plans* is a separate entity and won't appear in `<PricingTable />`. Plans aren't movable between tabs, recreate if misplaced.
+Plans for B2C must be registered as **User Plans**, not Organization Plans. A `pro` plan registered as an Organization Plan is a separate entity and won't appear in `<PricingTable />`. Plan type isn't changeable, recreate if misplaced.
 
 ## Core Pattern: User Plan Check
 
@@ -48,7 +48,7 @@ export default function PricingPage() {
 
 ## Tiered Feature Gating
 
-Prefer `has({ feature })` over `has({ plan })` for capability gating: features can move between plans without a code deploy (Dashboard or `clerk config patch`).
+Prefer `has({ feature })` over `has({ plan })` for capability gating: features can be reattached between plans without a code deploy.
 
 ```typescript
 import { auth } from '@clerk/nextjs/server'

--- a/skills/features/clerk-billing/references/b2c-patterns.md
+++ b/skills/features/clerk-billing/references/b2c-patterns.md
@@ -29,23 +29,6 @@ export default async function ProDashboard() {
 }
 ```
 
-## Full Pricing Page Setup
-
-```tsx
-import { PricingTable } from '@clerk/nextjs'
-
-export default function PricingPage() {
-	return (
-		<main className="max-w-4xl mx-auto py-12">
-			<h1>Choose your plan</h1>
-			<PricingTable />
-		</main>
-	)
-}
-```
-
-`<PricingTable />` fetches plan data from Clerk and renders plan cards that open Clerk's in-app checkout drawer on selection. No props required for basic usage.
-
 ## Tiered Feature Gating
 
 Prefer `has({ feature })` over `has({ plan })` for capability gating: features can be reattached between plans without a code deploy.

--- a/skills/features/clerk-billing/references/b2c-patterns.md
+++ b/skills/features/clerk-billing/references/b2c-patterns.md
@@ -6,7 +6,7 @@ B2C billing in Clerk attaches subscriptions to **individual users**. Each user g
 
 > **Prerequisite: personal accounts must be allowed.** If Organizations are enabled, open [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) and set **Membership options → "Membership optional"**. In "Membership required" mode personal accounts are disabled, `<PricingTable />` silently excludes any user without an active org (no error, no console warning). Check this first when a user reports "subscribe does nothing."
 
-Plans for B2C must be created under the **User Plans** tab in Dashboard → Billing → Plans. A `pro` plan under *Organization Plans* is a separate entity and won't appear in `<PricingTable />`. Plans aren't movable between tabs, recreate if misplaced.
+Plans for B2C must be created under the **User Plans** tab in Dashboard → Billing → Plans (or via `clerk config patch`, see SKILL.md → Agent-first). A `pro` plan under *Organization Plans* is a separate entity and won't appear in `<PricingTable />`. Plans aren't movable between tabs, recreate if misplaced.
 
 ## Core Pattern: User Plan Check
 
@@ -48,7 +48,7 @@ export default function PricingPage() {
 
 ## Tiered Feature Gating
 
-Prefer `has({ feature })` over `has({ plan })` for capability gating: features can move between plans in the Dashboard without a code deploy.
+Prefer `has({ feature })` over `has({ plan })` for capability gating: features can move between plans without a code deploy (Dashboard or `clerk config patch`).
 
 ```typescript
 import { auth } from '@clerk/nextjs/server'

--- a/skills/features/clerk-billing/references/b2c-patterns.md
+++ b/skills/features/clerk-billing/references/b2c-patterns.md
@@ -6,7 +6,7 @@ B2C billing in Clerk attaches subscriptions to **individual users**. Each user g
 
 > **Prerequisite: personal accounts must be allowed.** If Organizations are enabled, open [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) and set **Membership options → "Membership optional"**. In "Membership required" mode personal accounts are disabled, `<PricingTable />` silently excludes any user without an active org (no error, no console warning). Check this first when a user reports "subscribe does nothing."
 
-Plans for B2C must be registered as **User Plans**, not Organization Plans. A `pro` plan registered as an Organization Plan is a separate entity and won't appear in `<PricingTable />`. Plan type isn't changeable, recreate if misplaced.
+Plans for B2C must be created as **User Plans** (Dashboard → Billing → Plans → User Plans tab, or `clerk config patch` with `billing.plans`). A `pro` plan registered as an Organization Plan is a separate entity and won't appear in `<PricingTable />`. Plan type isn't changeable, recreate if misplaced.
 
 ## Core Pattern: User Plan Check
 


### PR DESCRIPTION
Closes [AIE-930](https://linear.app/clerk/issue/AIE-930).

## Summary
- New "Agent-first: Programmatic billing config" section showing:
  - `clerk config pull --keys billing` → edit → `clerk config patch --file billing.json --dry-run` flow
  - Raw `clerk api --platform PATCH /v1/platform/applications/{id}/instances/{id}/config` for one-shot updates
- Update STOP callout: clarify CLI can edit plans/features once billing is enabled (Dashboard-only toggle remains for the master switch only)
- Note that subscription lifecycle (PricingTable + webhooks) is unchanged — this only handles plan/feature config catalog
- Reference [AIE-823](https://linear.app/clerk/issue/AIE-823) for the future friendly wrapper swap

## Test plan
- [ ] Run `clerk config pull --keys billing` against a dev instance and confirm the schema
- [ ] Apply a sample plan via `clerk config patch --dry-run`
- [ ] Verify the raw `clerk api --platform` PATCH path works end-to-end