### PR TITLE
feat(orgs): add agent-first CLI sidebar

### DIFF
--- a/skills/features/clerk-orgs/SKILL.md
+++ b/skills/features/clerk-orgs/SKILL.md
@@ -13,13 +13,13 @@ metadata:
 
 # Organizations (B2B SaaS)
 
-> **STOP — Dashboard-only prerequisite.** Organizations must be enabled in the Clerk Dashboard before any org-related API, hook, or component works. Open [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) and enable Organizations. Pick the Membership mode deliberately: `Membership required` (default since 2025-08-22) routes signed-in users through the `choose-organization` task and disables personal accounts, while `Membership optional` keeps personal accounts available for B2C + B2B coexistence. Pick `optional` if you need personal subscriptions alongside org subscriptions.
+> **STOP — prerequisite.** Organizations must be enabled before any org-related API, hook, or component works. Two paths: (1) [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings), or (2) `clerk config patch` with `organization_settings.enabled` (see "Agent-first: Programmatic org management" below). Pick the Membership mode deliberately: `Membership required` (default since 2025-08-22) routes signed-in users through the `choose-organization` task and disables personal accounts, while `Membership optional` keeps personal accounts available for B2C + B2B coexistence. Pick `optional` if you need personal subscriptions alongside org subscriptions.
 >
 > **Version**: This skill targets current SDKs (`@clerk/nextjs` v7+, `@clerk/react` v6+ — Core 3). Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts — see `clerk` skill for the full version table.
 
 ## Quick Start
 
-1. **Enable Organizations** — [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings). Pick `Membership required` (B2B-only) or `Membership optional` (B2C + B2B). Dashboard-only; no CLI path.
+1. **Enable Organizations** — via [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings) or `clerk config patch` (see Agent-first section). Pick `Membership required` (B2B-only) or `Membership optional` (B2C + B2B).
 2. **Create an org** — via `<OrganizationSwitcher />`, `<CreateOrganization />`, or programmatically with `clerkClient().organizations.createOrganization()`.
 3. **Protect routes** — read `orgId` / `orgSlug` from `auth()` and gate with `has({ role })` or `has({ permission })`.
 4. **Manage members** — send invitations via Backend API or the built-in `<OrganizationProfile />` tab.
@@ -51,6 +51,78 @@ metadata:
 | Manage roles + permissions | `https://dashboard.clerk.com/last-active?path=organizations-settings/roles` |
 | Create/edit an organization | `https://dashboard.clerk.com/last-active?path=organizations` |
 | Webhooks for org events | `https://dashboard.clerk.com/last-active?path=webhooks` |
+
+## Agent-first: Programmatic org management
+
+Org settings (enable toggle, membership cap, admin delete, domains) are patchable via PLAPI Instance Config. Org CRUD + memberships + invitations live in BAPI. Useful for agents seeding orgs, replicating settings across instances, or version-controlling org structure.
+
+Pre-req: project linked (`clerk auth login` + `clerk link`, see `clerk-setup`).
+
+### Enable Organizations + settings via CLI
+
+```bash
+clerk api --platform PATCH /v1/platform/applications/<app_id>/instances/<ins_id>/config \
+  -d '{"organization_settings":{"enabled":true,"max_allowed_memberships":50,"domains_enabled":true,"admin_delete_enabled":true}}'
+```
+
+### Create / list / delete orgs (BAPI)
+
+```bash
+# Create:
+clerk api -X POST /v1/organizations \
+  -d '{"name":"Acme","slug":"acme","created_by":"user_xxx","max_allowed_memberships":10}'
+
+# List:
+clerk api /v1/organizations --query 'limit=20'
+
+# Get one:
+clerk api /v1/organizations/<org_id>
+
+# Update:
+clerk api -X PATCH /v1/organizations/<org_id> -d '{"name":"Acme Inc."}'
+
+# Delete:
+clerk api -X DELETE /v1/organizations/<org_id>
+```
+
+### Memberships
+
+```bash
+# Add a user to an org:
+clerk api -X POST /v1/organizations/<org_id>/memberships \
+  -d '{"user_id":"user_xxx","role":"org:admin"}'
+
+# List members:
+clerk api /v1/organizations/<org_id>/memberships --query 'limit=50'
+
+# Update role:
+clerk api -X PATCH /v1/organizations/<org_id>/memberships/<user_id> \
+  -d '{"role":"org:member"}'
+
+# Remove:
+clerk api -X DELETE /v1/organizations/<org_id>/memberships/<user_id>
+```
+
+### Invitations
+
+```bash
+# Send:
+clerk api -X POST /v1/organizations/<org_id>/invitations \
+  -d '{"email_address":"alice@example.com","role":"org:member","redirect_url":"https://app.com/accept"}'
+
+# List pending:
+clerk api /v1/organizations/<org_id>/invitations --query 'status=pending'
+
+# Revoke:
+clerk api -X POST /v1/organizations/<org_id>/invitations/<inv_id>/revoke \
+  -d '{"requesting_user_id":"user_xxx"}'
+```
+
+### Notes
+
+- This handles **org config + CRUD**. Subscription / billing for orgs (org plans, seat-limit pricing) flows through `clerk-billing` skill.
+- Roles + permissions catalog is editable in `references/roles-permissions.md`. Custom role creation goes through `clerk config patch` (instance-level role definitions) — see Dashboard's role editor for the UX equivalent.
+- For SSO / verified domain provisioning, see `references/enterprise-sso.md`.
 
 ## Documentation
 

--- a/skills/features/clerk-orgs/references/enterprise-sso.md
+++ b/skills/features/clerk-orgs/references/enterprise-sso.md
@@ -1,6 +1,6 @@
 # Enterprise SSO
 
-Per-organization SAML or OIDC. Configured via [Dashboard → Configure → Enterprise Connections](https://dashboard.clerk.com/last-active?path=user-authentication/enterprise-connections) or via `clerk api -X POST /v1/saml_connections`. New users from a matching domain auto-join via JIT Provisioning.
+Per-organization SAML or OIDC. Configured via [Dashboard → Configure → Enterprise Connections](https://dashboard.clerk.com/last-active?path=user-authentication/enterprise-connections) or via `clerk api -X POST /v1/enterprise_connections` (requires a plan with the SAML feature enabled). New users from a matching domain auto-join via JIT Provisioning.
 
 ## Configuration Flow
 
@@ -107,4 +107,4 @@ The `identifier` is the user's email. Clerk uses the domain to route to the corr
 - **Strategy name matters.** Core 3 uses `'enterprise_sso'`; Core 2 used `'saml'`. They are NOT interchangeable.
 - **Multiple connections per org is fine.** Typical enterprise: one SAML connection to Okta + one OIDC to Azure AD for different user segments / domains.
 - **Auto-join via JIT Provisioning.** Users who authenticate via an Organization's Enterprise SSO connection are added to the org automatically with the org's Default Role. No invitation step.
-- **Two setup paths.** Dashboard for interactive UI, or `clerk api` for scripted setup: `clerk api -X POST /v1/saml_connections` (create), `clerk api -X PATCH /v1/saml_connections/{id}` (update), `clerk api -X DELETE /v1/saml_connections/{id}` (remove). Pass the IdP metadata or client credentials in the request body; Clerk returns the ACS URL + Entity ID in the response.
+- **Two setup paths.** Dashboard for interactive UI, or `clerk api` for scripted setup: `clerk api -X POST /v1/enterprise_connections` (create), `clerk api -X PATCH /v1/enterprise_connections/{id}` (update), `clerk api -X DELETE /v1/enterprise_connections/{id}` (remove). Pass the IdP metadata or client credentials in the request body; Clerk returns the ACS URL + Entity ID in the response. Create / update endpoints require a plan with the SAML feature enabled. The legacy `/v1/saml_connections` endpoint is deprecated, use `/v1/enterprise_connections` instead.

--- a/skills/features/clerk-orgs/references/enterprise-sso.md
+++ b/skills/features/clerk-orgs/references/enterprise-sso.md
@@ -1,6 +1,6 @@
 # Enterprise SSO
 
-Per-organization SAML or OIDC. Configured in the Clerk Dashboard today (future CLI support planned — revisit this ref once the Clerk CLI ships for scripted connection setup). New users from a matching domain auto-join via JIT Provisioning.
+Per-organization SAML or OIDC. Configured via [Dashboard → Configure → Enterprise Connections](https://dashboard.clerk.com/last-active?path=user-authentication/enterprise-connections) or via `clerk api -X POST /v1/saml_connections`. New users from a matching domain auto-join via JIT Provisioning.
 
 ## Configuration Flow
 
@@ -107,4 +107,4 @@ The `identifier` is the user's email. Clerk uses the domain to route to the corr
 - **Strategy name matters.** Core 3 uses `'enterprise_sso'`; Core 2 used `'saml'`. They are NOT interchangeable.
 - **Multiple connections per org is fine.** Typical enterprise: one SAML connection to Okta + one OIDC to Azure AD for different user segments / domains.
 - **Auto-join via JIT Provisioning.** Users who authenticate via an Organization's Enterprise SSO connection are added to the org automatically with the org's Default Role. No invitation step.
-- **Setup is Dashboard-only today.** CLI support is planned; once it ships, scripted connection setup will be possible. Until then, scripted management goes through the Backend API.
+- **Two setup paths.** Dashboard for interactive UI, or `clerk api` for scripted setup: `clerk api -X POST /v1/saml_connections` (create), `clerk api -X PATCH /v1/saml_connections/{id}` (update), `clerk api -X DELETE /v1/saml_connections/{id}` (remove). Pass the IdP metadata or client credentials in the request body; Clerk returns the ACS URL + Entity ID in the response.

--- a/skills/features/clerk-orgs/references/roles-permissions.md
+++ b/skills/features/clerk-orgs/references/roles-permissions.md
@@ -36,7 +36,7 @@ If you reassign the Creator Role, ensure the replacement Role has these three at
 
 ## Custom Roles
 
-Up to 10 custom Roles per instance. Create via [Dashboard → Roles & Permissions](https://dashboard.clerk.com/last-active?path=organizations-settings/roles) → **Add role**, or via `clerk api -X POST /v1/role_sets/{role_set_key}/roles`. The key follows `org:<role>` format. Examples:
+Up to 10 custom Roles per instance. Create via [Dashboard → Roles & Permissions](https://dashboard.clerk.com/last-active?path=organizations-settings/roles) → **Add role**, or via `clerk api -X POST /v1/organization_roles` with body `{"name":"Billing Manager","key":"org:billing","description":"..."}`. The key follows `org:<role>` format. Examples:
 
 - `org:billing` — carries `org:sys_billing:manage`
 - `org:reports_viewer` — carries your custom `org:reports:view`
@@ -45,7 +45,7 @@ Up to 10 custom Roles per instance. Create via [Dashboard → Roles & Permission
 
 Naming convention: `org:<resource>:<action>`. Examples: `org:reports:view`, `org:api_keys:create`, `org:posts:edit`.
 
-Create via [Dashboard → Roles & Permissions](https://dashboard.clerk.com/last-active?path=organizations-settings/roles) → **Permissions** tab → **Add permission**, or via `clerk api -X POST /v1/organization_roles/{role_id}/permissions/{permission_id}` to attach an existing permission to a role. Permissions are attached to Roles inside a Role Set.
+Create via [Dashboard → Roles & Permissions](https://dashboard.clerk.com/last-active?path=organizations-settings/roles) → **Permissions** tab → **Add permission**, or via two steps: (1) `clerk api -X POST /v1/organization_permissions` with body `{"name":"Edit Posts","key":"org:posts:edit","description":"..."}` to create the permission, then (2) `clerk api -X POST /v1/organization_roles/{role_id}/permissions/{permission_id}` to attach it to a role. Permissions are attached to Roles inside a Role Set.
 
 ## Role Sets
 

--- a/skills/features/clerk-orgs/references/roles-permissions.md
+++ b/skills/features/clerk-orgs/references/roles-permissions.md
@@ -36,7 +36,7 @@ If you reassign the Creator Role, ensure the replacement Role has these three at
 
 ## Custom Roles
 
-Up to 10 custom Roles per instance. Create in Dashboard → Roles & Permissions → **Add role**. The key follows `org:<role>` format. Examples:
+Up to 10 custom Roles per instance. Create via [Dashboard → Roles & Permissions](https://dashboard.clerk.com/last-active?path=organizations-settings/roles) → **Add role**, or via `clerk api -X POST /v1/role_sets/{role_set_key}/roles`. The key follows `org:<role>` format. Examples:
 
 - `org:billing` — carries `org:sys_billing:manage`
 - `org:reports_viewer` — carries your custom `org:reports:view`
@@ -45,7 +45,7 @@ Up to 10 custom Roles per instance. Create in Dashboard → Roles & Permissions 
 
 Naming convention: `org:<resource>:<action>`. Examples: `org:reports:view`, `org:api_keys:create`, `org:posts:edit`.
 
-Create in Dashboard → Roles & Permissions → **Permissions** tab → **Add permission**. Permissions are attached to Roles inside a Role Set.
+Create via [Dashboard → Roles & Permissions](https://dashboard.clerk.com/last-active?path=organizations-settings/roles) → **Permissions** tab → **Add permission**, or via `clerk api -X POST /v1/organization_roles/{role_id}/permissions/{permission_id}` to attach an existing permission to a role. Permissions are attached to Roles inside a Role Set.
 
 ## Role Sets
 
@@ -113,7 +113,7 @@ import { Show } from '@clerk/nextjs'
 
 ## Key Rules
 
-- **Never invent permission slugs.** If you don't see it in the System Permissions catalog above or you haven't created it as a custom Permission in Dashboard, it doesn't exist.
+- **Never invent permission slugs.** If you don't see it in the System Permissions catalog above or you haven't created it as a custom Permission (Dashboard or BAPI), it doesn't exist.
 - **`org:` prefix is mandatory** for all org-scoped permissions.
 - **Always check `isLoaded` before trusting `has` on the client.** On first render `has` can be `undefined` — use optional chaining (`has?.()`) or guard on `isLoaded`.
 - **Case-sensitive.** `org:Admin` is not `org:admin`.


### PR DESCRIPTION
Closes [AIE-931](https://linear.app/clerk/issue/AIE-931).

## Summary
- New "Agent-first: Programmatic org management" section showing:
  - Enable Organizations + settings via PLAPI Instance Config PATCH (`organization_settings.enabled`, `max_allowed_memberships`, `domains_enabled`, `admin_delete_enabled`)
  - Org CRUD via BAPI (POST/GET/PATCH/DELETE `/v1/organizations`)
  - Memberships CRUD (add/list/update role/remove)
  - Invitations (send/list/revoke)
- Update STOP callout: Enable Organizations toggle is also doable via `clerk config patch`
- Update Quick Start step 1 to show both paths
- Note that org subscription/billing flows through `clerk-billing` skill
- Pointers to `references/roles-permissions.md` and `references/enterprise-sso.md` for deeper topics

## Test plan
- [ ] Verify `organization_settings.enabled` toggle works via `clerk config patch` against a dev instance
- [ ] Run `clerk api -X POST /v1/organizations` against a test app and confirm response shape
- [ ] Spot-check membership + invitation BAPI paths against current API reference