### PR TITLE
feat: add Clerk CLI skill

### DIFF
--- a/.agents/skills/audit-clerk-skill/SKILL.md
+++ b/.agents/skills/audit-clerk-skill/SKILL.md
@@ -20,7 +20,6 @@ This task needs a complete command inventory, not a quick grep pass. Build the s
 
 - **CLI source of truth**: a `clerk/cli` checkout containing `packages/cli-core/src/commands/**`, plus `packages/cli-core/src/cli.ts`, `cli-program.ts`, `mode.ts`, and any referenced files in `packages/cli-core/src/lib/`.
 - **Target skill**: `skills/core/clerk-cli/SKILL.md` and `skills/core/clerk-cli/references/*.md`.
-- **Template markers**: preserve placeholders such as `{{CLI_VERSION}}` if present. Do not expand them.
 
 ## Source Checkout Resolution
 
@@ -122,7 +121,6 @@ If invoked with `--apply`, apply `drift` and `gap` edits directly, then list `po
 - Never invent flags. If a flag appears in tests but not in the command parser, mark it for human review.
 - Preserve the existing `clerk-cli` skill's terse, third-person voice.
 - Do not use em dashes in proposals or edits.
-- Preserve `{{CLI_VERSION}}` and other template markers verbatim.
 - Keep `skills/core/clerk-cli/SKILL.md` near the 500-line guidance. Move detailed material to `references/` instead of bloating the main skill.
 - Do not treat the installed `clerk` binary as authoritative over source. Use `--help` only to confirm generated presentation when source and tests leave ambiguity.
 - Do not commit or print secrets. If the audit touches env guidance, preserve the repository's 1Password and no-plaintext-secret rules.

--- a/.agents/skills/audit-clerk-skill/SKILL.md
+++ b/.agents/skills/audit-clerk-skill/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: audit-clerk-skill
+description: Audits the bundled `clerk-cli` skill against the Clerk CLI source tree and proposes or applies updates. Use when the user says "audit the clerk-cli skill", "update the clerk-cli skill", "check clerk-cli against the CLI source", "resync clerk-cli skill", "run audit-clerk-skill", or after Clerk CLI commands, flags, or agent-mode behavior change.
+license: MIT
+effort: high
+user-invocable: true
+disable-model-invocation: true
+argument-hint: "[--source <path>] [--apply]"
+metadata:
+  internal: true
+---
+
+# Clerk CLI Skill Audit
+
+Cross-check `skills/core/clerk-cli/` in this repository against the actual Clerk CLI source and propose precise edits where the skill has drifted. The CLI is the source of truth; the skill is maintainer documentation that must track it.
+
+This task needs a complete command inventory, not a quick grep pass. Build the source model first, then compare it to the skill's current claims.
+
+## Inputs
+
+- **CLI source of truth**: a `clerk/cli` checkout containing `packages/cli-core/src/commands/**`, plus `packages/cli-core/src/cli.ts`, `cli-program.ts`, `mode.ts`, and any referenced files in `packages/cli-core/src/lib/`.
+- **Target skill**: `skills/core/clerk-cli/SKILL.md` and `skills/core/clerk-cli/references/*.md`.
+- **Template markers**: preserve placeholders such as `{{CLI_VERSION}}` if present. Do not expand them.
+
+## Source Checkout Resolution
+
+Resolve the CLI source checkout in this order:
+
+1. Use `--source <path>` when supplied. The path must contain `packages/cli-core/src/commands/`.
+2. If the current repository itself contains `packages/cli-core/src/commands/`, use the current repository root.
+3. If `CLERK_CLI_REPO` is set, use that path. Do not print the variable value if it contains sensitive path fragments.
+4. In Conductor, look for exactly one sibling workspace matching `../cli/*/packages/cli-core/src/commands/`. If multiple match, ask which one to use.
+5. If no checkout is available and network access is acceptable for the task, clone the public CLI repository into `.context/clerk-cli-source`:
+
+```sh
+mkdir -p .context
+cd .context
+git clone --depth 1 https://github.com/clerk/cli.git clerk-cli-source
+```
+
+If none of these work, stop and ask the user for a CLI source path. Do not audit against the installed `clerk` binary alone, because the binary may be stale and does not expose every source-level branch.
+
+## Workflow
+
+### 1. Inventory the CLI
+
+Walk `packages/cli-core/src/commands/` and build a structured inventory. For each top-level command and subcommand capture:
+
+- Full command path, such as `clerk config patch` or `clerk api ls`.
+- Purpose, from the command description or help string in source.
+- Flags, including short form, type, default, and destructive behavior.
+- Exit codes beyond the default if the command overrides them.
+- Agent-mode branches gated on `isAgentMode()`, `CLERK_MODE`, TTY detection, or related helpers.
+- Whether the command mutates remote state and needs `--dry-run`, `--yes`, or production-targeting guidance.
+
+Read `packages/cli-core/src/commands/<name>/README.md` as secondary context only. Use those files to flag mocked or stubbed commands and to cross-check API endpoint claims in `references/recipes.md`. Do not propose copying command READMEs into this repository; they include internal implementation detail and would bloat the skill.
+
+Also capture cross-cutting behavior:
+
+- Runner preference logic, including lockfile to package-runner mapping.
+- Auth, key resolution, `--app`, and `--instance` targeting.
+- `doctor` checks and `--json` output shape.
+- Agent-mode behavior for prompts, JSON defaults, browser opening, OAuth callbacks, deploy handoff, and sandbox warnings.
+- `clerk init --prompt` or equivalent handoff behavior if the skill mentions it.
+
+Prefer reading source over running the binary. When runtime behavior is unclear, use tests under `packages/cli-core/src/**/*.test.ts` or `packages/cli-core/src/test/` as supporting evidence.
+
+### 2. Extract the Skill's Claims
+
+Read `skills/core/clerk-cli/SKILL.md` and each file under `skills/core/clerk-cli/references/`. Extract every concrete claim:
+
+- Commands in the core command table and invocation guidance.
+- Flags named in prose, tables, and examples.
+- Agent-mode behavior bullets.
+- Exit code, error format, and JSON output claims.
+- Cross-references between `SKILL.md` and `references/*.md`.
+
+### 3. Diff Source Against Skill
+
+Produce a structured diff with four buckets:
+
+1. **Missing from skill**: commands, subcommands, flags, or behaviors that exist in source but are not mentioned anywhere in the skill.
+2. **Stale in skill**: claims in the skill that no longer match source, including renamed flags, changed defaults, removed commands, shifted exit codes, or reworked agent-mode branches.
+3. **Thin in skill**: commands mentioned but under-specified relative to their real complexity or footgun surface.
+4. **Over-specified**: details the skill encodes that `clerk <cmd> --help`, generated examples, or referenced files cover better.
+
+For buckets 1 through 3, cite both the source file and line and the target skill location.
+
+### 4. Decide Placement
+
+Route changes by maintenance value:
+
+- **Core loop, mental model, and safety** stay in `SKILL.md`.
+- **Per-command flag details, recipes, and edge cases** belong in `references/recipes.md` or a new reference file.
+- **Agent-mode branches** belong in `references/agent-mode.md`; `SKILL.md` gets only a concise summary.
+- **Auth, key resolution, and targeting** belong in `references/auth.md`.
+
+Prefer `clerk <command> --help` over duplicating generated help. Flags with destructive semantics, hidden interactions, or agent-mode divergence deserve skill coverage. Self-explanatory flags should usually be removed from prose and delegated to `--help`.
+
+Treat skill shrinkage as a valid proposal when it reduces drift risk. The goal is an accurate, durable skill, not a larger one.
+
+### 5. Propose Edits
+
+Emit a review-ready proposal. For each change include:
+
+- Path, such as `skills/core/clerk-cli/SKILL.md` or `skills/core/clerk-cli/references/agent-mode.md`.
+- Severity: `drift`, `gap`, or `polish`.
+- Why, with a source citation such as `packages/cli-core/src/commands/<cmd>/<file>.ts:<line>`.
+- Target location in this repository.
+- A unified diff when practical, otherwise a concise before and after block.
+
+Group the proposal by target file. Do not rewrite accurate neighboring sections just because they are nearby.
+
+### 6. Apply or Hand Back
+
+Default behavior: present the proposal and stop for review.
+
+If invoked with `--apply`, apply `drift` and `gap` edits directly, then list `polish` suggestions for review. After applying edits, run available formatting or validation commands for this repository. If no formatter exists, validate Markdown and JSON structure with lightweight checks.
+
+## Guardrails
+
+- Never invent flags. If a flag appears in tests but not in the command parser, mark it for human review.
+- Preserve the existing `clerk-cli` skill's terse, third-person voice.
+- Do not use em dashes in proposals or edits.
+- Preserve `{{CLI_VERSION}}` and other template markers verbatim.
+- Keep `skills/core/clerk-cli/SKILL.md` near the 500-line guidance. Move detailed material to `references/` instead of bloating the main skill.
+- Do not treat the installed `clerk` binary as authoritative over source. Use `--help` only to confirm generated presentation when source and tests leave ambiguity.
+- Do not commit or print secrets. If the audit touches env guidance, preserve the repository's 1Password and no-plaintext-secret rules.
+
+## Output Shape
+
+Return the proposal as:
+
+```markdown
+# clerk-cli skill audit - <YYYY-MM-DD>
+
+## Summary
+<counts per bucket, plus the largest drift>
+
+## skills/core/clerk-cli/SKILL.md
+### <section name>
+- [drift|gap|polish] <one-line description>
+  - source: packages/cli-core/src/commands/<...>:<line>
+  - target: skills/core/clerk-cli/SKILL.md:<line>
+  - change: <diff or concise before/after>
+
+## skills/core/clerk-cli/references/<file>.md
+...
+
+## New files
+...
+
+## Open questions
+...
+```
+
+Keep the result skimmable so a maintainer can approve, reject, or apply each entry independently.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,11 +11,12 @@
   "plugins": [
     {
       "name": "core",
-      "description": "Core Clerk skills: router, setup, custom UI, and API references",
+      "description": "Core Clerk skills: router, CLI operations, setup, custom UI, and API references",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/core/clerk",
+        "./skills/core/clerk-cli",
         "./skills/core/clerk-setup",
         "./skills/core/clerk-custom-ui",
         "./skills/core/clerk-backend-api"

--- a/.claude/skills/audit-clerk-skill
+++ b/.claude/skills/audit-clerk-skill
@@ -1,0 +1,1 @@
+../../.agents/skills/audit-clerk-skill

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -13,6 +13,7 @@
   "keywords": [
     "clerk",
     "auth",
+    "cli",
     "nextjs",
     "expo",
     "webhooks",
@@ -22,12 +23,13 @@
   "interface": {
     "displayName": "Clerk",
     "shortDescription": "Clerk auth, organizations, testing, and framework guidance",
-    "longDescription": "Official Clerk skills bundle for AI coding agents. Includes a router skill plus framework-specific patterns (Next.js, React, Vue, Nuxt, Astro, TanStack Start, Expo, React Router, Chrome Extension), feature skills (organizations, billing, webhooks, testing), and native mobile guidance (Swift, Android).",
+    "longDescription": "Official Clerk skills bundle for AI coding agents. Includes a router skill, Clerk CLI operations guidance, framework-specific patterns (Next.js, React, Vue, Nuxt, Astro, TanStack Start, Expo, React Router, Chrome Extension), feature skills (organizations, billing, webhooks, testing), and native mobile guidance (Swift, Android).",
     "developerName": "Clerk",
     "category": "Coding",
     "capabilities": ["Read", "Write"],
     "websiteURL": "https://clerk.com",
     "defaultPrompt": [
+      "List Clerk users with the Clerk CLI",
       "Add Clerk auth to my Next.js app",
       "Set up organizations for my B2B app",
       "Sync users to Postgres via Clerk webhooks"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .vscode
 .env*
 !.env.example
-.claude
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/audit-clerk-skill
 .DS_Store
 *-workspace/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,18 @@
 # Clerk Skills
 
-AI agent skills for Clerk authentication. 18 skills across 4 categories.
+AI agent skills for Clerk authentication. 21 public skills across 4 categories, plus internal maintenance skills under `.agents/skills/`.
 
 ## Structure
 
 ```
 skills/
-├── core/                          # clerk, setup, custom-ui, backend-api
+├── core/                          # clerk, cli, setup, custom-ui, backend-api
 ├── frameworks/            # nextjs, react, vue, nuxt, astro, tanstack, expo, react-router, chrome-extension
 ├── features/                      # orgs, webhooks, testing
 └── mobile/                 # swift, android
 ```
+
+Internal maintenance skills live in `.agents/skills/`. Mirror each one into `.claude/skills/` with a symlink to the same directory.
 
 ## Plugin Registry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,18 @@
 # Clerk Skills
 
-AI agent skills for Clerk authentication. 18 skills across 4 categories.
+AI agent skills for Clerk authentication. 21 public skills across 4 categories, plus internal maintenance skills under `.agents/skills/`.
 
 ## Structure
 
 ```
 skills/
-├── core/                          # clerk, setup, custom-ui, backend-api
+├── core/                          # clerk, cli, setup, custom-ui, backend-api
 ├── frameworks/            # nextjs, react, vue, nuxt, astro, tanstack, expo, react-router, chrome-extension
 ├── features/                      # orgs, webhooks, testing
 └── mobile/                 # swift, android
 ```
+
+Internal maintenance skills live in `.agents/skills/`. Mirror each one into `.claude/skills/` with a symlink to the same directory.
 
 ## Plugin Registry
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ git clone https://github.com/clerk/skills ~/.claude/skills/clerk
 | Skill | Purpose | When to Use |
 |-------|---------|-------------|
 | `/clerk` | **Router** - Routes to the right skill | Always start here |
+| `clerk-cli` | Clerk CLI operations | Users, orgs, apps, env keys, deploy checks |
 | `clerk-setup` | Add Clerk to any framework | New projects, framework setup |
 | `clerk-custom-ui` | Custom sign-in/up and appearance | Building custom forms, styling |
 | `clerk-backend-api` | Backend REST API explorer | Browsing or calling API endpoints |
@@ -109,6 +110,7 @@ CLERK_SECRET_KEY=sk_test_xxx
 
 | You Say | Skill Used |
 |---------|------------|
+| "List Clerk users" | `clerk-cli` |
 | "Add Clerk auth to my Next.js app" | `clerk-setup` |
 | "Use Server Actions with Clerk" | `clerk-nextjs-patterns` |
 | "Add Clerk to my Vue app" | `clerk-vue-patterns` |
@@ -138,6 +140,7 @@ clerk-skills/
 ├── skills/
 │   ├── core/
 │   │   ├── clerk/                  # Router skill
+│   │   ├── clerk-cli/              # CLI operations
 │   │   ├── clerk-setup/            # Framework setup
 │   │   ├── clerk-custom-ui/        # Component customization
 │   │   └── clerk-backend-api/      # REST API explorer

--- a/skills/core/clerk-cli/SKILL.md
+++ b/skills/core/clerk-cli/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: clerk-cli
+description: >-
+  Operate the Clerk CLI (`clerk` binary) for authentication, user/org/session management,
+  deploy verification, instance config, env keys, and any Clerk Backend or Platform API
+  call. Use when the user mentions Clerk management tasks, "list clerk users", "create a
+  clerk user", "update organization", "pull clerk config", "clerk env pull",
+  "clerk doctor", "clerk deploy", "clerk deploy status", "clerk api", or any ad-hoc
+  Clerk API request. Prefer the CLI over raw HTTP: it handles auth, key resolution,
+  app/instance targeting, and formatting automatically.
+license: MIT
+---
+
+# Clerk CLI
+
+The `clerk` binary is a pre-authenticated gateway to Clerk's Backend API and Platform API, plus project-level tooling (auth, linking, env pulls, instance config). When the user asks anything that touches a Clerk resource, reach for `clerk` first instead of hand-rolling `curl`.
+
+> This skill targets clerk `latest`. If `clerk --version` disagrees with the latest available CLI, refresh it with `clerk skill install` or a package runner such as `bunx clerk@latest`. The binary is always the source of truth, so run `clerk <command> --help` to verify anything this skill claims.
+
+## Execution environment (prefer the host, understand the sandbox warning)
+
+Most AI coding agents default to running shell commands in a sandbox where the
+user's home directory, OS keychain, browser launch, localhost callback
+binding, or network access may be blocked. The Clerk CLI depends on all of
+those host capabilities:
+
+- **OS credential store**: `clerk auth login` stores the OAuth token in the
+  system keychain. A sandbox without keychain access reports "not logged in"
+  even when the host is authenticated.
+- **Home-directory Clerk state**: saved config, cached metadata, and fallback
+  credentials live under the user's Clerk config/data directories.
+- **Linked project metadata**: resolved from the repo's git remote plus Clerk
+  config. Sandboxes with stripped repo state or blocked home-dir reads can
+  misreport "not linked".
+- **Local `.env*` files**: publishable and secret keys materialized by
+  `clerk env pull`.
+- **Outbound network access to Clerk**: every Backend and Platform API call.
+- **Browser + localhost OAuth callback**: `clerk auth login` needs both.
+
+In agent mode, the CLI now does a **best-effort warn-once check** at the
+host-sensitive library boundaries. When it detects that host-only Clerk state
+or system capabilities are unavailable, it emits:
+
+```text
+Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.
+Re-run this command on the host shell before trusting auth, link, env, or API failures.
+```
+
+Treat that warning as authoritative. The command may continue, but any auth,
+link, env, config, API, browser, or OAuth callback failure from that
+invocation is untrusted until you rerun the same command on the host.
+
+**Prefer these commands on the user's host shell, not in a sandbox:**
+
+`clerk doctor`, `clerk whoami`, `clerk auth login`, `clerk link`, `clerk env pull`,
+`clerk apps ...`, `clerk config ...`, `clerk api ...`.
+
+If a command was accidentally run in a sandbox and it reports `Not logged in`,
+`auth_required`, `not linked`, missing env, keychain/file permission errors,
+or network failures, **do not treat the result as authoritative**. Rerun it on
+the host before acting on it or reporting it to the user.
+
+## Invoking the CLI
+
+Before running any `clerk` command, figure out which binary to invoke and bind that choice for the rest of the session:
+
+```sh
+# 1. Prefer a globally installed binary when it matches the skill's target version.
+command -v clerk >/dev/null 2>&1 && clerk --version
+```
+
+If that prints `latest` or any version you trust, use bare `clerk` for the rest of the session.
+
+Otherwise fall back to a package runner, in this order (matches the CLI's own `preferredRunner` logic, which prefers the runner that matches the project's lockfile):
+
+| Project package manager   | Invocation                       |
+| ------------------------- | -------------------------------- |
+| bun (`bun.lock*`)         | `bunx clerk@latest`     |
+| npm (`package-lock.json`) | `npx -y clerk@latest`   |
+| pnpm (`pnpm-lock.yaml`)   | `pnpm dlx clerk@latest` |
+| yarn >= 2 (`yarn.lock`)   | `yarn dlx clerk@latest` |
+
+Yarn Classic (v1) has no `dlx`; treat those projects as "no preferred runner" and fall back to the first runner from the list above that's on PATH.
+
+The published npm package is **`clerk`**, not `@clerk/cli`. Never teach `npm install -g clerk` as the primary path. If the global CLI is stale or behaves differently from this skill, either upgrade the global install or fall back to the `latest` runner form above.
+
+## Prerequisites (run at session start)
+
+Before running any other Clerk command in a session, verify the CLI is authenticated, linked, and healthy:
+
+```sh
+clerk --version               # confirm the binary is on PATH
+clerk doctor --json           # structured health check; exit 1 if anything failed
+```
+
+**Always run `clerk doctor --json` first.** It catches the common setup failures (not logged in, project not linked, missing keys, stale CLI version) up front, so later commands don't fail with confusing errors. In agent mode it also includes a `Host execution` check that warns when Clerk's host-side config / credential directories are not writable, which is the canonical signal that the current invocation is likely sandboxed.
+
+Each result has `name`, `status` (`pass`/`warn`/`fail`), `message`, optional `detail`, optional `remedy` (how to fix it), and optional `fix` (label for auto-fixable issues). Parse that and act on it, or surface it to the user. If `Host execution` warns, rerun the command on the host before trusting any auth/link/env/API failures from the same sandboxed run. Rerun `clerk doctor --json` whenever a later command starts misbehaving.
+
+If `clerk --version` reports a newer CLI than this skill covers, trust `clerk <command> --help` first and refresh this skill bundle from its source.
+
+## The mental model
+
+| Layer                           | What it does                                                                                 | Commands                                                       |
+| ------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **Session / project**           | Auth, link a repo to a Clerk app, pull env keys                                              | `auth login`, `link`, `unlink`, `whoami`, `env pull`, `doctor` |
+| **Instance config**             | Manage the configuration (social providers, session lifetimes, etc.) for a specific instance | `config pull`, `config schema`, `config patch`, `config put`   |
+| **Backend API (default)**       | Runtime data: users, orgs, sessions, invitations, JWT templates, webhooks                    | `clerk api <path>`                                             |
+| **Platform API (`--platform`)** | Account-level: applications, instances, billing                                              | `clerk api --platform <path>`                                  |
+
+A project is "linked" to an application via `clerk link`. Once linked, most commands auto-resolve the target app and dev instance from the repo's git remote. To target something else, pass `--app <id>` and/or `--instance dev|prod|<instance_id>`. See [references/auth.md](references/auth.md) for the full resolution order.
+
+## Discover endpoints - don't memorize them
+
+The CLI ships with the Clerk OpenAPI catalog. Always discover endpoints dynamically instead of guessing paths:
+
+```sh
+clerk api ls                  # list every Backend API endpoint
+clerk api ls users            # filter by keyword (matches path, summary, tag, operationId)
+clerk api ls --platform apps  # list Platform API endpoints
+```
+
+Use this before `clerk api <path>`. If you don't see the endpoint you expected, it probably isn't exposed.
+
+## The `clerk api` command (the workhorse)
+
+`clerk api` makes authenticated HTTP calls. It auto-resolves keys, auto-detects method from body presence, supports stdin, and can preview mutations with `--dry-run`.
+
+```sh
+# GET requests
+clerk api /users                                  # list users
+clerk api /users/user_abc123                      # fetch one
+clerk api /users?limit=5&order_by=-created_at     # query params work inline
+
+# Mutating requests
+clerk api /users -d '{"email_address":["a@b.co"]}'          # POST (auto-detected from body)
+clerk api /users/user_abc123 -X PATCH -d '{"first_name":"A"}'
+clerk api /users/user_abc123 -X DELETE
+
+# Body from file or stdin
+clerk api /users --file payload.json
+cat payload.json | clerk api /users
+
+# Always preview mutations first
+clerk api /users/user_abc123 -X DELETE --dry-run
+clerk api /users/user_abc123 -X DELETE --yes      # skip confirmation once you've verified
+
+# Target a specific app/instance
+clerk api /users --app app_abc123 --instance prod
+
+# Include response headers when debugging
+clerk api /users --include
+
+# Platform API (account-level, not tenant data)
+clerk api /v1/platform/applications --platform
+```
+
+For instance config, prefer the dedicated `clerk config ...` commands over raw Platform API `/config` paths. They handle dry-run, diffing, and confirmation more cleanly than the raw endpoint form.
+
+**Always `--dry-run` a mutation before running it for real.** Then re-run without `--dry-run` (add `--yes` if you're sure). In agent mode, interactive confirmation is bypassed, so `--dry-run` is the only safety net for destructive calls.
+
+**JSON bodies must be valid JSON.** The CLI validates and rejects malformed payloads.
+
+**Endpoint paths may be given with or without `/v1/` prefix** - both work for Backend API calls. The CLI normalizes.
+
+See [references/recipes.md](references/recipes.md) for concrete patterns: listing/filtering users, creating orgs, impersonation sessions, etc.
+
+## Inspecting large outputs (do not flood your context)
+
+`users list`, `apps list`, `config pull`, and most `clerk api` GETs return payloads that can be many kilobytes or megabytes. Production tenants commonly have thousands of users; an instance config can be hundreds of fields deep. Reading those responses into the conversation costs context window for no benefit. Save the response to a file first, then query just what you need with `jq`:
+
+```sh
+# 1. Persist the response. Use --limit 250 to maximize page size for users list.
+clerk users list --json --limit 250 > /tmp/users.json
+clerk apps list --json                > /tmp/apps.json
+clerk api /users/user_abc123          > /tmp/user.json
+
+# 2. Inspect only what you need.
+jq '.data | length'                       /tmp/users.json   # current page size
+jq '.hasMore'                             /tmp/users.json   # are more pages available?
+jq '.data[0] | keys'                      /tmp/users.json   # discover the user shape once
+jq '.data[] | {id, email_addresses}'      /tmp/users.json   # project to a few fields
+jq '[.data[] | select(.banned)] | length' /tmp/users.json   # aggregate without reading rows
+```
+
+**If `jq` is not available**, fall back to Python or Node - both can stream the file without printing it whole:
+
+```sh
+python3 -c 'import json; d=json.load(open("/tmp/users.json")); print(len(d["data"]), d["hasMore"])'
+node -e 'const d=require("/tmp/users.json"); console.log(d.data.length, d.hasMore)'
+```
+
+`cat` / `head` the file only when you genuinely need to see the raw structure for one-off debugging. When walking pages, write each page to its own file (e.g. `page-${offset}.json`) so individual pages stay independently inspectable.
+
+## Core commands at a glance
+
+| Command                       | Purpose                                                                                                                                                                                                                                                                                                             | Key flags                                                                                                                                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clerk init`                  | Scaffold Clerk into a project. `--starter` only supports bootstrap for Next.js, React Router, Astro, Nuxt, TanStack Start, React, Vue, and JavaScript.                                                                                                                                                              | `--framework`, `--pm`, `--name` (with `--starter`), `--app`, `--starter`, `-y`, `--no-skills`                                                                                    |
+| `clerk auth login`            | OAuth browser login (stores token). Agent mode: no-op if already logged in. With no stored session it still opens a browser and binds a localhost callback, so it is not unattended; prefer `CLERK_PLATFORM_API_KEY` for headless flows. Aliases: `signup`, `signin`, `sign-in`. Top-level shortcut: `clerk login`. | -                                                                                                                                                                                |
+| `clerk auth logout`           | Clear stored credentials. Aliases: `signout`, `sign-out`. Top-level shortcut: `clerk logout`.                                                                                                                                                                                                                       | -                                                                                                                                                                                |
+| `clerk whoami`                | Print the logged-in email.                                                                                                                                                                                                                                                                                          | -                                                                                                                                                                                |
+| `clerk link` / `clerk unlink` | Link this repo to a Clerk app, or remove the link. `unlink` requires `--yes` in agent mode.                                                                                                                                                                                                                         | (see `--help`)                                                                                                                                                                   |
+| `clerk env pull`              | Write publishable + secret keys to the framework's env file (merge, not clobber). Resolves `.env.development.local` → framework-preferred file → `.env.local`; override with `--file`.                                                                                                                              | (see `--help`)                                                                                                                                                                   |
+| `clerk config {pull,schema}`  | Fetch instance config JSON, or its JSON Schema.                                                                                                                                                                                                                                                                     | (see `--help`)                                                                                                                                                                   |
+| `clerk config patch`          | Partial update (PATCH) of instance config. Pass `--destructive` to actually delete sub-resources touched by the patch rather than resetting them to defaults.                                                                                                                                                       | `--app`, `--instance`, `--file`, `--json`, `--dry-run`, `--yes`, `--destructive`                                                                                                 |
+| `clerk config put`            | Full replacement (PUT) of instance config. Pass `--destructive` to actually delete removed sub-resources rather than resetting them to defaults.                                                                                                                                                                    | `--app`, `--instance`, `--file`, `--json`, `--dry-run`, `--yes`, `--destructive`                                                                                                 |
+| `clerk apps {list,create}`    | List or create Clerk applications. Defaults to JSON in agent mode.                                                                                                                                                                                                                                                  | (see `--help`)                                                                                                                                                                   |
+| `clerk users` (no subcommand) | Interactive picker for `users` actions in human mode; in agent mode prints the action list and exits `2`. Always pass an explicit subcommand from agents.                                                                                                                                                           | `--app`, `--instance`, `--secret-key`                                                                                                                                            |
+| `clerk users list`            | List users via curated BAPI flags. JSON output (default when piped or in agent mode) is `{data, hasMore}` so callers can paginate without `/users/count`. `--limit` defaults to 100 (max 250).                                                                                                                      | `--limit`, `--offset`, `--query`, `--email-address`, `--phone-number`, `--username`, `--user-id`, `--external-id`, `--order-by`, `--json`, `--app`, `--instance`, `--secret-key` |
+| `clerk users create`          | Create a user from curated flags or a raw BAPI body. Confirmation prompt unless `--yes`.                                                                                                                                                                                                                            | `--email`, `--phone`, `--username`, `--password`, `--first-name`, `--last-name`, `--external-id`, `-d, --data`, `--file`, `--dry-run`, `--yes`, `--json`                         |
+| `clerk users open [user-id]`  | Open a user's dashboard page. Agent mode requires `user-id` and prints a JSON descriptor instead of launching a browser.                                                                                                                                                                                            | (see `--help`)                                                                                                                                                                   |
+| `clerk open [subpath]`        | Open the linked app's dashboard in a browser. Agent mode: prints a JSON descriptor instead of opening.                                                                                                                                                                                                              | (see `--help`)                                                                                                                                                                   |
+| `clerk deploy`                | Human-mode production deploy wizard. Agent mode: emits a read-only JSON handoff and tells the agent whether to ask the human to run the wizard, wait for provisioning, finish OAuth, or do nothing.                                                                                                                 | `--mode agent`, `--mode human`, `--verbose`                                                                                                                                      |
+| `clerk deploy status`         | Read-only deploy verification. Triggers a DNS check, reports aggregate domain and OAuth readiness, and exits `0` only when complete. Agent mode does one quick check by default; pass `--wait` to keep waiting.                                                                                                     | `--mode agent`, `--wait`, `--verbose`                                                                                                                                            |
+| `clerk doctor`                | Health check (CLI version, login, link, env, config, completion; plus host-execution probe in agent mode).                                                                                                                                                                                                          | `--json`, `--spotlight`, `--verbose`, `--fix`                                                                                                                                    |
+| `clerk api [path]`            | Authenticated HTTP to Backend/Platform API.                                                                                                                                                                                                                                                                         | `-X`, `-d`, `--file`, `--dry-run`, `--yes`, `--include`, `--app`, `--secret-key`, `--instance`, `--platform`                                                                     |
+| `clerk api ls [filter]`       | Discover endpoints from the bundled OpenAPI catalog.                                                                                                                                                                                                                                                                | (see `--help`)                                                                                                                                                                   |
+| `clerk completion [shell]`    | Print a shell completion script (`bash`, `zsh`, `fish`, `powershell`).                                                                                                                                                                                                                                              | -                                                                                                                                                                                |
+| `clerk update`                | Update the CLI to the latest version.                                                                                                                                                                                                                                                                               | `--channel`, `-y`, `--all`                                                                                                                                                       |
+| `clerk skill install`         | Reinstall the bundled `clerk-cli` skill from the CLI. In this standalone bundle, update the skill source directly instead.                                                                                                                                                                                          | (see `--help`)                                                                                                                                                                   |
+
+**`clerk <command> --help` is the source of truth for flags.** This table is a hint, not a spec. Before running an unfamiliar command or flag combination, run `clerk <command> --help` once per session. Every command also defines `setExamples([...])` in source, which `--help` renders as a copy-pasteable Examples block, so you rarely need to guess syntax.
+
+## Agent-mode behavior (important)
+
+The CLI auto-detects agent mode when stdout is not a TTY, or when `--mode agent` / `CLERK_MODE=agent` is set. In agent mode:
+
+- **Interactive prompts are disabled.** Commands that would normally show pickers (`link` without `--app`, `unlink` without `--yes`, `users` without a subcommand) either auto-resolve or exit with a usage error. `clerk api` with no args prints usage guidance and exits 0; pass an endpoint (or `ls`) explicitly. Always pass explicit flags (`--app`, `--yes`) in scripted calls.
+- **Host-sensitive operations emit a sandbox warning once per invocation.** Home-directory Clerk state, keychain access, networked Clerk calls, browser launch, and localhost OAuth callback setup can trigger the warning shown above. If it appears, rerun the same command on the host before trusting the result.
+- **If your harness does not clearly present as agent mode, force it.** Use `--mode agent` or `CLERK_MODE=agent` when you want the CLI's non-interactive behavior and sandbox warning path to apply deterministically.
+- **`link` supports deterministic agent flows.** In agent mode, `clerk link --app <id>` links directly. Without `--app`, the CLI will try silent key-based autolink first; if it cannot determine the app unambiguously, it exits and tells you to pass `--app`.
+- **`init` never selects or creates a real Clerk app for you in agent mode unless authenticated or given a target.** Pass `--app <id>` (or pre-link the project) to authenticate and link a real app, or pass `--keyless` to use auto-generated temporary development keys when bootstrapping a new project on a keyless-capable framework. Without either, agent mode prints manual setup guidance and exits cleanly.
+- **`unlink` requires `--yes` in agent mode.** This preserves the same safety bar as other destructive commands while still letting an agent complete the unlink non-interactively.
+- **Mutations still require `--yes`** unless you accept per-call confirmation is impossible.
+- **`doctor --fix` is ignored.** Parse `doctor --json` output's `remedy` field and act on it yourself.
+- **`apps list` and `apps create` default to JSON** when piped.
+- **`users` defaults to JSON when piped, like `apps`.** `clerk users list` and `clerk users create` emit JSON in agent mode. Bare `clerk users` (no subcommand) is a usage error in agent mode - pass `list`, `create`, or `open` explicitly. `clerk users open` requires the `user-id` positional in agent mode and prints a JSON descriptor instead of launching a browser.
+- **`deploy` has an agent handoff plus a verification gate.** In agent mode, bare `clerk deploy` is read-only and emits a JSON handoff. It never drives the interactive wizard. Do not tell Claude or another agent to run `! clerk deploy`, because the wizard needs interactive stdin prompts. Ask the human to run `clerk deploy` in a new terminal window when needed, then run `clerk deploy status --mode agent` to verify completion. See [references/agent-mode.md](references/agent-mode.md#deploy-handoff-and-verification).
+- **`--input-json <json|@file|->`** expands JSON into flags on any command (e.g. `clerk init --input-json '{"framework":"next","yes":true}'`). Piped stdin is also accepted: `echo '{"yes":true}' | clerk init`. Place `--input-json` after the leaf subcommand. Full rules in [references/agent-mode.md](references/agent-mode.md#passing-options-as-json---input-json).
+
+Full matrix and sandbox details in [references/agent-mode.md](references/agent-mode.md).
+
+## Output format and errors
+
+- **JSON output:** `--json` on `apps list` and `doctor`. For `clerk api`, the response body is the raw API JSON, so pipe into `jq` freely.
+- **Exit codes:** `0` success, `1` runtime error, `2` usage/validation error. `doctor` returns `1` if any check failed.
+- **Error format:** User-facing errors print a single line to stderr and set a non-zero exit code. Use `--verbose` for stack traces when debugging.
+
+## Safety rules for autonomous use
+
+1. **Discover before acting:** `clerk api ls <keyword>` before `clerk api <path>`.
+2. **Preview mutations:** `--dry-run` on every `config patch`, `config put`, `api -X POST/PATCH/PUT/DELETE`.
+3. **Target explicitly in production:** pass `--instance prod` rather than relying on defaults, and confirm with the user before any production mutation.
+4. **Never commit secrets:** `env pull` writes to `.env.local` (which should be gitignored). Don't paste secret keys into code or chat.
+5. **Use `doctor --json`** to diagnose before assuming the CLI is broken.
+
+## References
+
+- [references/auth.md](references/auth.md) - auth flow, key resolution order, host-vs-sandbox behavior, `--app`/`--instance` targeting, Backend vs Platform API.
+- [references/recipes.md](references/recipes.md) - copy-pasteable recipes for common Clerk tasks.
+- [references/agent-mode.md](references/agent-mode.md) - agent-mode behavior matrix, sandbox warning semantics, exit codes, error format.

--- a/skills/core/clerk-cli/references/agent-mode.md
+++ b/skills/core/clerk-cli/references/agent-mode.md
@@ -1,0 +1,287 @@
+# Clerk CLI - Agent Mode Reference
+
+The Clerk CLI has a first-class "agent" mode that's designed for non-interactive and AI-driven use. Read this before writing scripts or letting an LLM drive the CLI.
+
+## Sandbox warning semantics
+
+Agent mode and sandboxing are related but not identical:
+
+- **Agent mode** controls non-interactive behavior.
+- **Sandboxing** controls whether the CLI can actually reach host-only Clerk
+  state and host system capabilities.
+
+In agent mode, the CLI now performs a **best-effort warn-once check** at the
+host-sensitive integration boundaries. The first time an invocation hits a
+blocked host capability, it emits:
+
+```text
+Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.
+Re-run this command on the host shell before trusting auth, link, env, or API failures.
+```
+
+Treat that warning as authoritative. The command may still continue and return
+an ordinary Clerk error, but any auth/link/env/config/API/browser/OAuth
+failure from that invocation should be treated as suspect until rerun on the
+host.
+
+The warning can be triggered by:
+
+- home-directory Clerk config / credential file access
+- OS keychain access
+- outbound Clerk network requests
+- browser launch
+- localhost callback server binding for OAuth
+
+If your harness does not obviously look non-interactive, force agent behavior
+with `--mode agent` or `CLERK_MODE=agent` so the CLI's non-interactive and
+sandbox-warning paths apply deterministically.
+
+## How agent mode is detected
+
+Priority (first match wins):
+
+1. `--mode agent` flag on the command line
+2. `CLERK_MODE=agent` environment variable
+3. Stdout is not a TTY (piped, redirected, or running under an agent harness)
+
+Force human mode with `--mode human` or `CLERK_MODE=human`. Typical AI-agent invocations automatically land in agent mode because stdout is piped.
+
+## What changes in agent mode
+
+| Behavior                                                         | Human mode                                | Agent mode                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Interactive pickers (`link` without `--app`, `api` with no args) | Show a TUI picker                         | Print structured guidance and exit, or auto-resolve                                                                                                                                                                                                                                                                                                                                                                                  |
+| `clerk link --app <id>`                                          | Links directly                            | Links directly                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `clerk link` without `--app`                                     | Interactive picker / create UI            | Tries silent autolink from detected publishable keys; if no deterministic match exists, exits with a usage error telling the caller to pass `--app`                                                                                                                                                                                                                                                                                  |
+| Confirmation prompts (`unlink`, `config patch`, `api -X DELETE`) | Prompt y/n                                | Require `--yes`, otherwise error                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `clerk doctor --fix`                                             | Interactively offers fixes                | **Ignored**; output the `remedy` field and let the caller act                                                                                                                                                                                                                                                                                                                                                                        |
+| `clerk apps list` default output                                 | Table                                     | JSON (when piped)                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `clerk apps create <name>` output                                | Human-readable summary                    | JSON (auto-detected, same as `apps list`); `--json` also works explicitly                                                                                                                                                                                                                                                                                                                                                            |
+| `clerk users list` / `clerk users create` default output         | Table / human-readable                    | JSON (auto-detected when piped); `--json` also works explicitly                                                                                                                                                                                                                                                                                                                                                                      |
+| `clerk users` (no subcommand)                                    | Interactive action picker                 | Prints the action list and exits with a usage error (code `2`) - pass `list` / `create` / `open`                                                                                                                                                                                                                                                                                                                                     |
+| `clerk users open [user-id]`                                     | Picks a user interactively, opens browser | Requires `user-id`; prints `{url, appId, appName, instanceId, instanceLabel, userId, opened: false}` and does not open a browser                                                                                                                                                                                                                                                                                                     |
+| `clerk open [subpath]`                                           | Opens the browser to the URL              | Does not open a browser. Prints a JSON descriptor (`{url, appId, appName, instanceId, instanceLabel, subpath, opened: false}`) on stdout so the agent can surface it                                                                                                                                                                                                                                                                 |
+| `clerk deploy`                                                   | Interactive production deploy wizard      | Read-only handoff. Emits deploy status JSON on stdout and exits `0` for linked projects. Does not prompt, mutate, trigger DNS checks, or poll.                                                                                                                                                                                                                                                                                       |
+| `clerk deploy status`                                            | Verify production deploy state            | Read-only verification gate. Triggers one DNS check for active production domains, waits briefly, reads one live status snapshot, emits status JSON on stdout, exits `0` when complete and `1` when incomplete. It does not keep waiting or back off in agent mode unless `--wait` is passed. Use `--wait` when the user asks the agent to keep waiting for DNS, SSL, email DNS, or final Clerk-side readiness.                      |
+| `clerk auth login` when already authenticated                    | Prompt to re-auth                         | Silent no-op                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `clerk init`                                                     | Full interactive scaffold flow            | Runs non-interactively. Explicit `--app` or a linked profile uses the real-app auth/link/env flow; without it, an authenticated agent on a keyless-capable framework creates a real app and links it. Pass `--keyless` to opt into auto-generated dev keys for new projects on keyless-capable frameworks. Without `--keyless`, an unauthenticated agent (or non-keyless framework with no app target) prints manual setup guidance. |
+| Color / spinners                                                 | Enabled                                   | Disabled                                                                                                                                                                                                                                                                                                                                                                                                                             |
+
+In addition, sandboxed agent-mode invocations may emit the warning above once
+per CLI invocation when a host-sensitive operation is blocked.
+
+**Rule of thumb:** always pass `--yes` for mutations and `--json` for structured output where available. Pass `--app` / `--instance` when you intentionally target a real app; pass `--keyless` to opt into auto-generated dev keys when bootstrapping a new project without authenticating.
+
+## Passing options as JSON: `--input-json`
+
+Every command accepts `--input-json <json|@file|->`. Keys convert from camelCase/snake_case to kebab-case and expand into flags before Commander parses argv - so anything a command accepts as a flag can come from JSON instead.
+
+```sh
+clerk init --input-json '{"framework":"next","yes":true}'
+clerk config pull --input-json '{"keys":["auth_email","session"]}'  # arrays → repeated flags
+clerk init --input-json @init-opts.json                             # read JSON from a file
+clerk init --input-json -                                           # read JSON from stdin
+echo '{"framework":"next","yes":true}' | clerk init                 # auto-detect piped stdin
+```
+
+When `--input-json` is omitted and stdin is piped (not a TTY), the CLI automatically reads JSON from stdin - no flag needed. This lets agents pipe options directly: `echo '{"yes":true}' | clerk init`.
+
+Positional arguments (e.g. the `<name>` in `clerk apps create <name>`) cannot come from JSON - only flag-style options can.
+
+| JSON             | Expansion                               |
+| ---------------- | --------------------------------------- |
+| `"str"` / number | `--flag <value>`                        |
+| `true`           | `--flag`                                |
+| `false` / `null` | omitted                                 |
+| `["a","b"]`      | `--flag a --flag b` (empty arrays omit) |
+| `{…}` (nested)   | rejected - `invalid_json`, exit `2`     |
+
+**Placement.** Put `--input-json` after the leaf subcommand. Before it, flags land on the root program, so only `--mode` / `--verbose` work there - subcommand flags (`--json`, `--app`, etc.) error as unknown. Explicit flags after `--input-json` override its values (last-flag-wins).
+
+Errors use the standard agent-mode format: bad JSON → `invalid_json`, missing `@file` → `file_not_found`, unknown expanded flags → Commander's `unknown option`. All exit `2`.
+
+## Exit codes
+
+| Code | Meaning                                                                      |
+| ---- | ---------------------------------------------------------------------------- |
+| `0`  | Success                                                                      |
+| `1`  | Runtime error (auth failure, API error, file I/O, etc.)                      |
+| `2`  | Usage or validation error (bad flags, malformed JSON body, unknown endpoint) |
+
+`clerk doctor` exits `1` when any check fails (warnings alone still exit `0`).
+
+## Error output format
+
+**Human mode:**
+
+- Single-line error message on stderr.
+- Stack traces hidden unless `--verbose` is passed.
+- API errors include the first message from the response body, prefixed with a human context string (e.g., `Failed to fetch config: unauthorized`).
+
+**Agent mode:**
+
+- Structured JSON on stderr: `{"error":{"code":"...","message":"...","docsUrl?":"...","errors?":[...]}}`.
+- `code` is a machine-readable error code (e.g., `auth_required`, `api_error`, `unexpected_error`).
+- `errors` array is present for API errors and mirrors the Clerk API error shape (`{code?, message?, meta?}`).
+- `docsUrl` is present when the error has associated documentation.
+
+**Both modes:**
+
+- User-aborted commands exit cleanly with no error output.
+- When handling errors programmatically, read stderr, check the exit code, and re-run with `--verbose` to get a trace if you need to debug.
+
+## Structured outputs you can rely on
+
+| Command                                       | Structured output                                                                             |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `clerk doctor --json`                         | `[{name, status, message, detail?, remedy?, fix?}]`                                           |
+| `clerk apps list --json`                      | Array of application objects                                                                  |
+| `clerk apps create --json`                    | Single application object                                                                     |
+| `clerk users list` (agent mode or `--json`)   | `{data: [...users], hasMore}` envelope (BAPI user shape inside `data`)                        |
+| `clerk users create` (agent mode or `--json`) | Single user object (raw BAPI shape)                                                           |
+| `clerk users open` (agent mode)               | `{url, appId, appName, instanceId, instanceLabel, userId, opened: false}`                     |
+| `clerk api <path>`                            | Raw API JSON (Backend or Platform) on stdout                                                  |
+| `clerk api <path> --include`                  | Response headers on stderr, body on stdout                                                    |
+| `clerk config pull`                           | Instance config JSON                                                                          |
+| `clerk config schema`                         | JSON Schema                                                                                   |
+| `clerk open [subpath]`                        | `{url, appId, appName, instanceId, instanceLabel, subpath, opened: false}` (agent mode)       |
+| `clerk open --print`                          | Plain dashboard URL on stdout                                                                 |
+| `clerk deploy` (agent mode)                   | Deploy handoff report with `complete`, `state`, domain status, OAuth status, and `nextAction` |
+| `clerk deploy status` (agent mode)            | Deploy verification report with the same shape, plus exit `0` complete or `1` incomplete      |
+| Any command (agent mode)                      | On error: `{"error":{"code","message","docsUrl?","errors?"}}` on stderr                       |
+
+For commands without an explicit `--json` flag, `clerk api` is your escape hatch: hit the underlying endpoint directly.
+
+## Patterns for agent-driven use
+
+### Diagnose before acting
+
+```sh
+clerk doctor --json --spotlight
+```
+
+Parse the output, then for each failing check read `remedy` and act. Never call `--fix` from an agent - it's interactive.
+
+In agent mode, `doctor` also includes a **`Host execution`** check when it can
+detect that Clerk's host-side state is not writable. If that check warns, stop
+trusting auth/link/env/API failures from the same sandboxed run and rerun the
+relevant command on the host.
+
+### Preview every mutation
+
+```sh
+# Dry run first
+clerk api /users/user_abc123 -X DELETE --dry-run
+# If the preview is what you expected, run it with --yes
+clerk api /users/user_abc123 -X DELETE --yes
+```
+
+### Target explicitly
+
+```sh
+# Don't rely on the linked profile for critical operations
+clerk api /users --app app_abc123 --instance prod
+```
+
+The same advice applies to linking in agent mode: `clerk link --app app_abc123` is deterministic and works non-interactively. If you omit `--app`, the command only succeeds when silent autolink can prove the target app from existing publishable keys.
+
+### Deploy handoff and verification
+
+Do not try to drive the interactive deploy wizard from an agent. Use the handoff and check commands instead.
+
+```sh
+# 1. Inspect current production deploy state without mutating anything.
+clerk deploy --mode agent
+
+# 2. If the handoff says a human action is needed, ask the user to run this
+#    in a new terminal window, not through `! clerk deploy`:
+clerk deploy --mode human
+
+# 3. After the user finishes or DNS has had time to propagate, verify:
+clerk deploy status --mode agent
+
+# 4. If the user asks you to keep waiting, use the retrying wait loop:
+clerk deploy status --mode agent --wait
+```
+
+`clerk deploy --mode agent` is read-only. It resolves the linked app and current production deploy snapshot, then emits JSON on stdout. It does **not** trigger DNS checks, poll, create production instances, patch OAuth config, or prompt. Linked projects exit `0` because this is an informational handoff. Not-linked and API failures still use the normal agent error envelope on stderr.
+
+Never try to run the human wizard through Claude's `! clerk deploy` shell escape or any non-interactive agent shell. The deploy wizard asks for domain, DNS export, OAuth, and verification inputs over stdin, so it needs a real human terminal. Tell the user to open a new terminal window in the project directory and run `clerk deploy` or `clerk deploy --mode human` there. After they finish, return to agent mode and run `clerk deploy status --mode agent`.
+
+`clerk deploy status --mode agent` is the gate. It is also read-only with respect to deploy configuration, but for an active production domain it triggers one Clerk DNS check, waits briefly, reads a live status/config snapshot, then reports DNS, SSL, email DNS, aggregate domain readiness, and OAuth completeness. By default it does not keep waiting or exponentially back off in agent mode. If the check is incomplete and the user asks the agent to continue waiting, run `clerk deploy status --mode agent --wait` instead of manually sleeping and retrying. `--wait` uses the shared poll loop: one immediate status read, then up to 5 exponential-backoff retries until aggregate domain status is complete. It emits the same status JSON. It exits:
+
+| Exit | Meaning                                                                              |
+| ---- | ------------------------------------------------------------------------------------ |
+| `0`  | Deploy is complete and verified.                                                     |
+| `1`  | The check ran successfully, but deploy is incomplete. Read `state` and `nextAction`. |
+| else | A real CLI error occurred. Read the standard agent error envelope on stderr.         |
+
+Deploy-specific agent errors still use the standard envelope and may include typed codes such as `plan_insufficient`, `provider_domain_not_allowed`, `home_url_taken`, or `form_param_invalid`.
+
+When a production instance exists, `nextAction` includes the full Clerk Dashboard domains URL so agents can send the user directly to the same page the human CLI prints in its next steps. Always show that URL to the user. Ask whether they want you to open it for them instead of omitting or paraphrasing it away.
+
+The deploy report has this shape:
+
+```json
+{
+  "complete": false,
+  "state": "domain_pending",
+  "domain": "example.com",
+  "productionInstanceId": "ins_...",
+  "domainStatus": { "dns": "complete", "ssl": "pending", "mail": "complete" },
+  "pendingDnsRecords": [{ "type": "CNAME", "host": "clerk.example.com", "value": "..." }],
+  "oauth": { "complete": true, "configured": ["google"], "pending": [], "unsupported": [] },
+  "nextAction": "SSL still provisioning for example.com. Re-run `clerk deploy status` in a few minutes, DNS propagation can take time. Ask the user to visit the Clerk Dashboard domains page, or offer to open it: https://dashboard.clerk.com/apps/app_.../instances/ins_.../domains"
+}
+```
+
+`complete` is `true` only when the aggregate domain status is complete and all supported OAuth providers enabled in development have production credentials. The `domainStatus` object is a component summary; DNS, SSL, and email DNS can all read `complete` while `state` remains `domain_pending` if Clerk-side finalization is still pending.
+
+State precedence:
+
+| State                 | What to do                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `not_started`         | Ask the human to run `clerk deploy --mode human`, then run `clerk deploy status --mode agent`.                                |
+| `domain_provisioning` | Wait briefly or ask the human to finish `clerk deploy`, then run `clerk deploy status --mode agent`.                          |
+| `domain_pending`      | Surface `pendingDnsRecords` when present. Re-run `clerk deploy status --mode agent` after DNS, SSL, or email DNS propagation. |
+| `oauth_pending`       | Ask the human to finish the OAuth credential steps in `clerk deploy --mode human`, then verify with `deploy status`.          |
+| `complete`            | No action needed.                                                                                                             |
+
+Unsupported OAuth providers do not block `complete`, because the wizard cannot configure them automatically. They are still surfaced in `oauth.unsupported` so you can warn the user to review them in the Clerk Dashboard.
+
+### Use the catalog, not hard-coded paths
+
+```sh
+clerk api ls users            # discover available user endpoints
+clerk api ls --platform apps   # platform-side endpoints
+```
+
+### Surface doctor remedies to the user
+
+When `clerk doctor --json` reports a failure, show the user the `name`, `message`, and `remedy` - don't just silently try to fix it, because the underlying fix (e.g., `clerk auth login`) usually requires human interaction.
+
+`clerk doctor --fix` is disabled in agent mode, so you cannot rely on it. If a caller wants to attempt remediation anyway, map the failing check to the command that would fix it in human mode. Each check exposes this mapping via the optional `fix.label` field on the JSON result:
+
+| Failing check           | Manual remediation                           |
+| ----------------------- | -------------------------------------------- |
+| `Logged in`             | `clerk auth login`                           |
+| `Authentication valid`  | `clerk auth login`                           |
+| `CLI configuration`     | `clerk auth login`                           |
+| `Project linked`        | `clerk link`                                 |
+| `Application reachable` | `clerk link`                                 |
+| `Instance IDs`          | `clerk link`                                 |
+| `Environment variables` | `clerk env pull`                             |
+| `CLI version`           | (no auto-fix; run `clerk update`)            |
+| `Shell completion`      | (no auto-fix; see `clerk completion --help`) |
+
+All three remediation commands are themselves interactive by default: `auth login` opens a browser, `link` prompts for an app when `--app` is omitted, and `env pull` writes a file. In agent mode, prefer `clerk link --app <id>` over bare `clerk link`, since the bare form only works when silent autolink can resolve the target app without a picker.
+
+## What NOT to do in agent mode
+
+- **Don't ignore the sandbox warning.** If the CLI says host-only Clerk state or system capabilities may be unavailable, rerun the same command on the host before trusting the result.
+- **Don't assume `clerk auth login` is fully unattended from an agent** - it opens a browser and waits for a callback. Prefer `CLERK_PLATFORM_API_KEY` for headless automation. `clerk init --app <id>` or init in an already linked project may still invoke the normal login fallback when a real app target is explicit.
+- **Don't call `clerk link` without `--app` and assume the agent can pick for you** - it only succeeds when silent autolink can determine the app from detected keys.
+- **Don't run `clerk unlink` in agent mode without `--yes`** - it exits with a usage error instead of prompting.
+- **Don't run `clerk config put` without `--dry-run` first** - it's a full replacement and is destructive.
+- **Don't skip `--yes` on mutations and expect them to work** - agent mode disables prompts, so commands that require confirmation will error.
+- **Don't leak secret keys into logs** - the CLI never prints the raw secret key, and you shouldn't either.

--- a/skills/core/clerk-cli/references/auth.md
+++ b/skills/core/clerk-cli/references/auth.md
@@ -1,0 +1,155 @@
+# Clerk CLI - Authentication & Targeting Reference
+
+Everything you need to know about how the CLI authenticates, resolves keys, and targets the right application/instance.
+
+## Two APIs, two auth paths
+
+Clerk exposes two HTTP APIs. The CLI speaks both.
+
+| API                      | Base URL                    | Auth                                                                   | Used for                                                                                           | CLI flag     |
+| ------------------------ | --------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------ |
+| **Backend API (BAPI)**   | `https://api.clerk.dev/v1/` | Instance **secret key** (`sk_...`)                                     | Tenant data: users, orgs, sessions, invitations, JWT templates, webhooks.                          | (default)    |
+| **Platform API (PLAPI)** | `https://api.clerk.com/v1/` | **Platform API key** (`ak_...`) or OAuth token from `clerk auth login` | Account-level: listing your applications, fetching app/instance metadata, pulling config, billing. | `--platform` |
+
+You override the base URLs via `CLERK_BACKEND_API_URL` and `CLERK_PLATFORM_API_URL` when testing against non-production Clerk environments.
+
+### Backend API secret key resolution order
+
+When you run `clerk api /users` (no `--platform`), the CLI picks the `sk_` key in this order:
+
+1. `--secret-key <key>` flag (explicit override)
+2. `CLERK_SECRET_KEY` environment variable
+3. Auto-resolved from `--app <id>` (uses `CLERK_PLATFORM_API_KEY` or stored OAuth token to fetch the app's secret key)
+4. Auto-resolved from the linked project profile (same mechanism as #3, but the app ID comes from the repo's link)
+
+The CLI validates prefixes: passing `ak_...` where `sk_...` is expected (or vice versa) throws an error immediately with guidance on which key type to use.
+
+### Platform API auth resolution order
+
+When you run `clerk api --platform ...`, or any command that already uses PLAPI (`apps list`, `config pull`, `link`, etc.), the CLI picks the bearer token in this order:
+
+1. `CLERK_PLATFORM_API_KEY` environment variable
+2. Stored OAuth token from `clerk auth login`
+3. If neither is present, the CLI errors: "Not authenticated. Run `clerk auth login` or set `CLERK_PLATFORM_API_KEY`."
+
+Set `CLERK_PLATFORM_API_KEY` for CI and scripted agent usage. Use `clerk auth login` for local interactive development.
+
+## Host vs sandbox behavior
+
+These auth and targeting rules only produce trustworthy results when the CLI
+can actually reach the user's host state.
+
+In agent mode, the CLI now emits a best-effort warning once per invocation
+when it detects that host-only Clerk state or system capabilities are
+unavailable:
+
+```text
+Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.
+Re-run this command on the host shell before trusting auth, link, env, or API failures.
+```
+
+That warning usually means one of the following is blocked:
+
+- Clerk home-directory config or fallback credential files
+- OS keychain access
+- outbound Clerk network access
+- browser launch or localhost OAuth callback setup
+
+When that warning appears, stop trusting the current invocation's auth or
+targeting result. A sandboxed run can misreport:
+
+- `Not logged in` / `auth_required`
+- `Not authenticated. Run clerk auth login or set CLERK_PLATFORM_API_KEY`
+- `No Clerk project linked`
+- missing env or missing linked profile state
+
+Rerun the same command on the host before acting on it.
+
+> **`config` commands do not accept `--secret-key`.** They target the Platform API and authenticate via the PLAPI chain above (`CLERK_PLATFORM_API_KEY` or the stored OAuth token). If you need to script `config pull/schema/patch/put` in CI, export `CLERK_PLATFORM_API_KEY`; a Backend API `sk_...` key will not work.
+
+## Project linking
+
+`clerk link` stores a mapping from your repo to a Clerk application in the CLI config file (run `clerk doctor --verbose` to see the resolved path; override with `CLERK_CONFIG_DIR`). The key is the normalized git remote URL (e.g., `github.com/org/repo`), which means the link is shared across all clones and worktrees of the same repo automatically.
+
+When you run a command without `--app`/`--instance`:
+
+1. The CLI resolves the current repo's profile (normalized git remote → git common dir → current working directory).
+2. If linked, it uses the stored app ID and instance IDs.
+3. If not linked, it errors with guidance to run `clerk link`.
+
+## `--app` and `--instance` targeting
+
+Most commands accept `--app <id>` and `--instance <target>` to override the linked profile:
+
+- `--app <id>` - Clerk application ID (starts with `app_`). Works from any directory; no link required.
+- `--instance <target>` - One of:
+  - `dev` (development instance, the default)
+  - `prod` (production instance)
+  - a full instance ID (starts with `ins_`)
+
+Examples:
+
+```sh
+# Operate on a specific app without linking the repo
+clerk api /users --app app_abc123
+
+# Pull production env keys (dangerous - only when you know what you're doing)
+clerk env pull --app app_abc123 --instance prod
+
+# Target a specific instance directly
+clerk config pull --instance ins_2aB3c...
+```
+
+## Auth commands
+
+### `clerk auth login`
+
+Aliases: `signup`, `signin`, `sign-in`. Top-level shortcut: `clerk login`.
+
+OAuth 2.0 PKCE flow against the Clerk OAuth system instance (`https://clerk.clerk.com` by default, overridable via `CLERK_OAUTH_BASE_URL`):
+
+1. Generates PKCE parameters.
+2. Starts a local callback server on `127.0.0.1`.
+3. Opens the browser to `/oauth/authorize`.
+4. Exchanges the code at `/oauth/token` for an access token.
+5. Fetches user info from `/oauth/userinfo`.
+6. Stores the token in the OS credential store.
+
+In agent mode, if already authenticated, it's a no-op. If not, it prints guidance rather than opening a browser.
+In a sandbox, even the "already authenticated" check can be false if the
+keychain or fallback credential file is blocked, so rerun on the host before
+trusting a sandboxed auth failure.
+
+### `clerk auth logout`
+
+Aliases: `signout`, `sign-out`. Top-level shortcut: `clerk logout`.
+
+Clears the stored token. No API calls.
+
+### `clerk whoami`
+
+Hits `GET /oauth/userinfo` with the stored token and prints the email. Exits with a message if not logged in.
+
+## Environment variables the CLI honors
+
+| Variable                 | Effect                                                          |
+| ------------------------ | --------------------------------------------------------------- |
+| `CLERK_MODE`             | Force `human` or `agent` mode (overrides TTY detection).        |
+| `CLERK_SECRET_KEY`       | BAPI secret key (bypasses linked project / `--app` resolution). |
+| `CLERK_PLATFORM_API_KEY` | PLAPI bearer key.                                               |
+| `CLERK_BACKEND_API_URL`  | Override Backend API base URL.                                  |
+| `CLERK_PLATFORM_API_URL` | Override Platform API base URL.                                 |
+| `CLERK_OAUTH_BASE_URL`   | Override OAuth base URL (advanced / internal).                  |
+| `CLERK_CONFIG_DIR`       | Override config, cache, and credential directory (advanced).    |
+
+## Common auth failure modes
+
+| Symptom                             | Likely cause                                                  | Fix                                                          |
+| ----------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| `Not authenticated`                 | No token stored, no `CLERK_PLATFORM_API_KEY`                  | `clerk auth login` or export `CLERK_PLATFORM_API_KEY`        |
+| `No Clerk project linked`           | Running a command that needs a linked profile with no `--app` | `clerk link` or pass `--app <id>`                            |
+| `Invalid secret key prefix`         | Passed `ak_...` where `sk_...` expected (or vice versa)       | Check which API the command hits; pass the matching key type |
+| `Unauthorized` from API             | Key belongs to a different instance                           | Verify `--instance` and ensure the key matches               |
+| Sandbox warning + auth/link failure | Host-only Clerk state or system capabilities are blocked      | Rerun the same command on the host before trusting the error |
+
+When in doubt: `clerk doctor --json` walks through all of this and tells you exactly what's wrong.

--- a/skills/core/clerk-cli/references/recipes.md
+++ b/skills/core/clerk-cli/references/recipes.md
@@ -1,0 +1,299 @@
+# Clerk CLI - Recipes
+
+Copy-pasteable patterns for common tasks. Treat these as starting points; confirm exact paths and parameters with `clerk api ls <keyword>` and `clerk <command> --help`, since the Clerk API evolves.
+
+## Discovery first
+
+```sh
+clerk api ls                  # everything Backend API exposes
+clerk api ls users            # filter by keyword
+clerk api ls --platform       # Platform API (account-level)
+```
+
+The bundled catalog is cached locally for 1 hour. There is no force-refresh flag - once the TTL expires the next `clerk api ls` re-fetches automatically; on fetch failure the CLI falls back to the stale cache and prints a warning.
+
+## Users
+
+```sh
+# List users (preferred; curated flags). --limit defaults to 100 (max 250).
+# JSON output is `{ data: [...], hasMore }` so callers can paginate without /users/count.
+clerk users list
+clerk users list --limit 50 --offset 0 --order-by -created_at
+
+# Count users (no curated subcommand; use the raw API)
+clerk api /users/count
+
+# Fetch a user (no curated subcommand; use the raw API)
+clerk api /users/user_abc123
+
+# Search by email
+clerk users list --email-address alice@example.com
+
+# Open a user's profile in the dashboard
+clerk users open user_abc123
+clerk users open user_abc123 --print     # print the URL instead of opening
+
+# Create a user (preferred; curated flags)
+clerk users create \
+  --email alice@example.com \
+  --password 'SuperSecret123!' \
+  --first-name Alice \
+  --last-name Doe \
+  --yes
+
+# Equivalent raw BAPI call. Use only when curated flags don't cover a field.
+clerk api /users -d '{
+  "email_address": ["alice@example.com"],
+  "password": "SuperSecret123!",
+  "first_name": "Alice",
+  "last_name": "Doe"
+}'
+
+# Update (PATCH merges)
+clerk api /users/user_abc123 -X PATCH -d '{"first_name":"Alicia"}'
+
+# Ban / unban
+clerk api /users/user_abc123/ban -X POST
+clerk api /users/user_abc123/unban -X POST
+
+# Lock / unlock
+clerk api /users/user_abc123/lock -X POST
+clerk api /users/user_abc123/unlock -X POST
+
+# Delete (PREVIEW FIRST)
+clerk api /users/user_abc123 -X DELETE --dry-run
+clerk api /users/user_abc123 -X DELETE --yes
+```
+
+### Test users (development only)
+
+For test accounts you need to sign into without real email or SMS delivery, Clerk provides two magic patterns that both verify with the fixed OTP `424242`. Use them on development instances; production rejects them.
+
+**By email.** Any address with the `+clerk_test` subaddress is recognized as a test email. The domain portion is arbitrary.
+
+```sh
+# Create a test user with a test email (dev instance)
+# `skip_password_checks` isn't a curated flag, so pass the body via `-d`.
+clerk users create -d '{
+  "email_address": ["demo+clerk_test@example.com"],
+  "password": "TestPass123!",
+  "skip_password_checks": true
+}' --yes
+```
+
+**By phone.** Any US fictional phone number in the `+1 (XXX) 555-0100` through `+1 (XXX) 555-0199` range is recognized as a test phone. Pass the E.164 form.
+
+```sh
+# Create a test user with a test phone (dev instance)
+clerk users create -d '{
+  "phone_number": ["+12015550100"],
+  "password": "TestPass123!",
+  "skip_password_checks": true
+}' --yes
+```
+
+When signing in as either user in a browser or Playwright, enter `424242` at the OTP prompt.
+
+These patterns only apply to development instances. In production, client trust blocks sign-in regardless of suffix or number, and using real-looking test addresses is highly discouraged. Test addresses and numbers do not count against the dev-instance monthly caps (20 SMS, 100 emails). See [Clerk's test emails and phones reference](https://clerk.com/docs/guides/development/testing/test-emails-and-phones) for the full contract.
+
+## Organizations
+
+```sh
+# List
+clerk api /organizations
+clerk api '/organizations?limit=20&query=acme'
+
+# Fetch
+clerk api /organizations/org_abc123
+
+# Create
+clerk api /organizations -d '{"name":"Acme","created_by":"user_abc123"}'
+
+# Update
+clerk api /organizations/org_abc123 -X PATCH -d '{"name":"Acme Inc."}'
+
+# Members
+clerk api /organizations/org_abc123/memberships
+clerk api /organizations/org_abc123/memberships -d '{"user_id":"user_xyz","role":"org:member"}'
+clerk api /organizations/org_abc123/memberships/user_xyz -X PATCH -d '{"role":"org:admin"}'
+clerk api /organizations/org_abc123/memberships/user_xyz -X DELETE --dry-run
+
+# Invitations
+clerk api /organizations/org_abc123/invitations -d '{"email_address":"new@acme.com","role":"org:member"}'
+```
+
+If organization endpoints return `organization_not_enabled_in_instance`, enable the feature first:
+
+```sh
+# Inspect org settings
+clerk api /instance/organization_settings
+
+# Preview, then enable organizations for this instance
+clerk api /instance/organization_settings -X PATCH -d '{"enabled":true}' --dry-run
+clerk api /instance/organization_settings -X PATCH -d '{"enabled":true}' --yes
+```
+
+## Sessions
+
+```sh
+# List active sessions for a user
+clerk api '/sessions?user_id=user_abc123&status=active'
+
+# Revoke a session
+clerk api /sessions/sess_abc123/revoke -X POST
+
+# Create an impersonation / sign-in token (for testing)
+clerk api /sign_in_tokens -d '{"user_id":"user_abc123"}'
+```
+
+## Invitations (top-level, not org-scoped)
+
+```sh
+clerk api /invitations
+clerk api /invitations -d '{"email_address":"new@example.com","redirect_url":"https://example.com/welcome"}'
+clerk api /invitations/inv_abc123/revoke -X POST
+```
+
+## JWT templates
+
+```sh
+clerk api /jwt_templates
+clerk api /jwt_templates/jtmp_abc123
+clerk api /jwt_templates -d '{
+  "name": "supabase",
+  "claims": {"aud": "authenticated", "role": "authenticated"},
+  "lifetime": 60
+}'
+```
+
+## Instance configuration
+
+Prefer the dedicated `config` commands over raw `api` calls - they handle confirmation, dry-run, and formatting.
+
+```sh
+# Pull the current dev config
+clerk config pull
+clerk config pull --output config.dev.json
+
+# Pull production
+clerk config pull --instance prod --output config.prod.json
+
+# Look at the schema to know what's available
+clerk config schema --keys session sign_in social
+
+# PATCH: surgical updates
+clerk config patch --json '{"session":{"lifetime":3600}}' --dry-run
+clerk config patch --json '{"session":{"lifetime":3600}}' --yes
+
+# PUT: replace everything (destructive - always --dry-run first)
+clerk config put --file config.prod.json --dry-run
+clerk config put --file config.prod.json --instance prod --yes
+```
+
+## Environment variables
+
+```sh
+# Pull dev keys into .env.local (auto-detects framework and key names)
+clerk env pull
+
+# Pull production keys
+clerk env pull --instance prod
+
+# Target a specific file
+clerk env pull --file .env
+```
+
+`env pull` merges into the existing file: existing Clerk keys are updated in place; new ones are appended under a `# Clerk` header; everything else is preserved.
+
+## Applications (Platform API)
+
+```sh
+# List your apps
+clerk apps list
+clerk apps list --json
+
+# Fetch one (raw API)
+clerk api /v1/platform/applications/app_abc123 --platform
+```
+
+## Scripting patterns
+
+### Save large responses to a file before reading them
+
+`users list`, `apps list`, `config pull`, and most `clerk api` GETs can return responses ranging from kilobytes to megabytes. Reading the full payload into an LLM-driven session burns context for no benefit. Persist the response, then query just the slice you need:
+
+```sh
+# Persist once, query as many times as you need.
+clerk users list --json --limit 250 > /tmp/users.json
+
+jq '.data | length'                   /tmp/users.json   # count rows on the page
+jq '.hasMore'                         /tmp/users.json   # any more pages?
+jq '.data[0] | keys'                  /tmp/users.json   # learn the shape of one record
+jq '.data[] | {id, email_addresses}'  /tmp/users.json   # project to relevant fields only
+```
+
+If `jq` is not on `PATH`, fall back to Python or Node, which most environments have:
+
+```sh
+python3 -c 'import json; d=json.load(open("/tmp/users.json")); print(len(d["data"]), d["hasMore"])'
+node    -e 'const d=require("/tmp/users.json"); console.log(d.data.length, d.hasMore)'
+```
+
+Only `cat`/`head` the file when you genuinely need the raw structure for one-off debugging.
+
+### Pipe to `jq`
+
+For small responses (or one-shot lookups), inline piping to `jq` is fine:
+
+```sh
+# Get a list of user IDs from the current page (the page envelope is `{ data, hasMore }`)
+clerk users list --json | jq -r '.data[] | .id'
+
+# Count banned users on the current page
+clerk users list --json | jq '[.data[] | select(.banned)] | length'
+
+# Walk every page until hasMore is false. Save each page to its own file so you
+# can inspect them independently without re-fetching.
+offset=0
+while :; do
+  page="/tmp/users-${offset}.json"
+  clerk users list --json --limit 250 --offset "$offset" > "$page"
+  jq -r '.data[] | .id' "$page"
+  [ "$(jq -r '.hasMore' "$page")" = "true" ] || break
+  offset=$((offset + 250))
+done
+```
+
+### Read body from stdin
+
+```sh
+echo '{"first_name":"Bob"}' | clerk api /users/user_abc123 -X PATCH
+jq -n '{email_address:["c@d.co"]}' | clerk api /users
+```
+
+### Loop safely
+
+```sh
+# Always --dry-run first across the whole set. `users list` paginates;
+# bump --limit (max 250) and walk pages with --offset until .hasMore is false.
+for id in $(clerk users list --json --limit 250 | jq -r '.data[] | .id'); do
+  clerk api /users/$id -X PATCH -d '{"public_metadata":{"migrated":true}}' --dry-run
+done
+# Re-run without --dry-run once the previews look right
+```
+
+### Target multiple instances
+
+```sh
+# Copy config from dev to staging for review
+clerk config pull --instance dev --output /tmp/dev-config.json
+clerk config patch --instance ins_staging --file /tmp/dev-config.json --dry-run
+```
+
+## When in doubt
+
+```sh
+clerk api ls <keyword>        # find the right endpoint
+clerk <command> --help        # authoritative flag list
+clerk doctor --json           # health check
+```

--- a/skills/core/clerk/SKILL.md
+++ b/skills/core/clerk/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: clerk
-description: Clerk authentication router. Use when user asks about adding authentication,
-  setting up Clerk, custom sign-in flows, Swift or native iOS auth, native Android
-  auth, Next.js patterns, React patterns, Vue patterns, Nuxt patterns, Astro patterns,
-  TanStack Start patterns, Expo patterns, React Router patterns, Chrome Extension patterns,
-  organizations, billing, subscriptions, payments, pricing, plans, seat-based pricing,
-  feature entitlements, syncing users, or testing. Automatically routes to the specific
-  skill based on their task.
+description: Clerk authentication router. Use when user asks about Clerk CLI operations,
+  adding authentication, setting up Clerk, custom sign-in flows, Swift or native iOS
+  auth, native Android auth, Next.js patterns, React patterns, Vue patterns, Nuxt
+  patterns, Astro patterns, TanStack Start patterns, Expo patterns, React Router
+  patterns, Chrome Extension patterns, organizations, billing, subscriptions, payments,
+  pricing, plans, seat-based pricing, feature entitlements, syncing users, or testing.
+  Automatically routes to the specific skill based on their task.
 license: MIT
 metadata:
   version: 2.0.0
@@ -38,6 +38,12 @@ All skills are written for the current SDK. When something differs in Core 2, it
 - Framework detection and quickstart
 - Environment setup, API keys, Keyless flow
 - Migration from other auth providers
+
+**Operating Clerk from the CLI** → Use `clerk-cli`
+- Auth, linking, `doctor`, and environment pulls
+- User, org, session, app, and instance management
+- Backend and Platform API calls through `clerk api`
+- Deploy handoff and deploy status verification
 
 **Custom sign-in/sign-up UI** → Use `clerk-custom-ui`
 - Custom authentication flows with `useSignIn` / `useSignUp` hooks
@@ -133,6 +139,7 @@ All skills are written for the current SDK. When something differs in Core 2, it
 
 If you know your task, you can directly access:
 - `/clerk-setup` - Framework setup
+- `/clerk-cli` - CLI operations and Clerk resource management
 - `/clerk-custom-ui` - Custom flows & appearance
 - `/clerk-nextjs-patterns` - Next.js patterns
 - `/clerk-react-patterns` - React patterns


### PR DESCRIPTION
Adds a public `clerk-cli` skill for operating the Clerk CLI, including references for auth, agent mode, and common recipes.

Wires the skill into the core plugin manifest, router, README, and Codex metadata.

Adds an internal `.agents/skills/audit-clerk-skill` workflow, mirrored into `.claude/skills`, for keeping the CLI skill synced with Clerk CLI source.
