### PR TITLE
fix: update react-router skill for React Router v8

### DIFF
--- a/skills/frameworks/clerk-react-router-patterns/SKILL.md
+++ b/skills/frameworks/clerk-react-router-patterns/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: clerk-react-router-patterns
-description: 'React Router v7 patterns with Clerk — rootAuthLoader, getAuth in loaders,
+description: 'React Router v7/v8 patterns with Clerk — rootAuthLoader, getAuth in loaders,
   clerkMiddleware, protected routes, SSR user data, org switching. Triggers on: react-router
   auth, rootAuthLoader, getAuth loader, react-router protected route, loader authentication,
-  SSR auth react-router.'
+  SSR auth react-router, useNavigate may be used only in the context of a Router.'
 license: MIT
 allowed-tools: WebFetch
 metadata:
   author: clerk
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # React Router Patterns
 
-SDK: `@clerk/react-router` v3+. Requires React Router v7.9+.
+SDK: `@clerk/react-router` v3.5+. Supports React Router v7.9+ and v8.
 
 ## What Do You Need?
 
@@ -23,9 +23,91 @@ SDK: `@clerk/react-router` v3+. Requires React Router v7.9+.
 | Protected routes and redirects | references/protected-routes.md |
 | SSR user data and session | references/ssr-auth.md |
 
+## React Router v7 vs v8
+
+Check the installed `react-router` major version before scaffolding — the config differs:
+
+| | v7.9+ | v8+ |
+|--|--|--|
+| Middleware API | Opt-in: set `future: { v8_middleware: true }` in `react-router.config.ts` | Always on — do NOT set the flag (v8 removed it) |
+| `ssr.noExternal` workaround (below) | Not needed | **Required** |
+
+## Minimal Setup
+
+### 1. vite.config.ts (v8 only — REQUIRED)
+
+React Router v8 ships development/production conditional exports. In `react-router dev`,
+Vite externalizes `@clerk/react-router` for SSR, so Node resolves the production build of
+react-router while the app code gets the development build — two module instances, two
+Router contexts. Every request then fails during SSR with:
+
+```
+Error: useNavigate() may be used only in the context of a <Router> component.
+```
+
+**`npm ls react-router` shows a single copy — that does NOT rule this out.** The
+duplication is per export condition, not per installed copy. Do not chase duplicate
+installs; add the workaround (upstream issue:
+https://github.com/remix-run/react-router/issues/15232):
+
+```ts
+import { reactRouter } from '@react-router/dev/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [reactRouter()],
+  ssr: {
+    noExternal: ['@clerk/react-router'],
+  },
+})
+```
+
+### 2. root.tsx
+
+```tsx
+import { Outlet } from 'react-router'
+import { rootAuthLoader, clerkMiddleware } from '@clerk/react-router/server'
+import { ClerkProvider } from '@clerk/react-router'
+import type { Route } from './+types/root'
+
+export const middleware: Route.MiddlewareFunction[] = [clerkMiddleware()]
+
+export async function loader(args: Route.LoaderArgs) {
+  return rootAuthLoader(args)
+}
+
+export default function App({ loaderData }: Route.ComponentProps) {
+  return (
+    <ClerkProvider loaderData={loaderData}>
+      <Outlet />
+    </ClerkProvider>
+  )
+}
+```
+
+There is no `ClerkApp` HOC in `@clerk/react-router` (that was the `@clerk/remix` API).
+Render `<ClerkProvider loaderData={loaderData}>` inside the default export and pass it
+the root route's `loaderData`.
+
+### 3. react-router.config.ts (v7 only)
+
+```ts
+import type { Config } from '@react-router/dev/config'
+
+export default {
+  future: {
+    v8_middleware: true,
+  },
+} satisfies Config
+```
+
+On v8, omit the `future` block entirely — the flag no longer exists.
+
+> **Required**: `rootAuthLoader` must be called in `root.tsx`'s loader. Without it, `getAuth` throws in nested loaders.
+
 ## Mental Model
 
-React Router v7 uses a middleware + loader pipeline. Clerk plugs into both layers:
+React Router v7/v8 uses a middleware + loader pipeline. Clerk plugs into both layers:
 
 - **Middleware** (`clerkMiddleware()`) — runs on every request, attaches auth to context
 - **`rootAuthLoader`** — required in `root.tsx` to pass Clerk state to the client
@@ -37,33 +119,6 @@ Request → clerkMiddleware() → rootAuthLoader → page loader → component
            attaches auth      injects state     getAuth(args)
            to context         to response       reads context
 ```
-
-## Minimal Setup
-
-### 1. root.tsx
-
-```tsx
-import { rootAuthLoader } from '@clerk/react-router/server'
-import { ClerkApp } from '@clerk/react-router'
-import type { Route } from './+types/root'
-
-export async function loader(args: Route.LoaderArgs) {
-  return rootAuthLoader(args)
-}
-
-export default ClerkApp(function App() {
-  return <Outlet />
-})
-```
-
-### 2. Middleware (root route or entry.server.ts)
-
-```tsx
-import { clerkMiddleware } from '@clerk/react-router/server'
-export const middleware = [clerkMiddleware()]
-```
-
-> **Required**: `rootAuthLoader` must be called in `root.tsx`'s loader. Without it, `getAuth` throws in nested loaders.
 
 ## Auth in Loaders
 
@@ -132,7 +187,10 @@ export async function loader(args: Route.LoaderArgs) {
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `clerkMiddleware() not detected` | Missing middleware | Export `middleware = [clerkMiddleware()]` from root route |
+| `useNavigate() may be used only in the context of a <Router>` thrown from ClerkProvider during SSR in dev (v8) | Vite dev SSR externalizes `@clerk/react-router`, which then loads react-router's production build while the app uses the development build — two Router contexts. A single copy in `npm ls` does not rule this out. | Add `ssr: { noExternal: ['@clerk/react-router'] }` to `vite.config.ts`. Do NOT downgrade to v7 |
+| Build error: `ClerkApp` is not exported | `ClerkApp` does not exist in `@clerk/react-router` | Use `<ClerkProvider loaderData={loaderData}>` in root.tsx's default export |
+| `clerkMiddleware() not detected` | Missing middleware (or on v7, missing `v8_middleware` future flag) | Export `middleware = [clerkMiddleware()]` from root route; on v7 also set `future: { v8_middleware: true }` |
+| Unknown future flag error/warning (v8) | `v8_middleware` flag left in `react-router.config.ts` after upgrading | Remove the `future.v8_middleware` entry — middleware is always on in v8 |
 | `getAuth` returns empty userId | `rootAuthLoader` not called | Call `rootAuthLoader(args)` in `root.tsx` loader |
 | Infinite redirect loop | Redirect target is also protected | Exclude `/sign-in` from protection check |
 | `redirect` not working in action | Using `Response` instead of `throw redirect()` | Use `throw redirect('/path')` from `react-router` |
@@ -144,7 +202,7 @@ export async function loader(args: Route.LoaderArgs) {
 | `getAuth` | `@clerk/react-router/server` |
 | `rootAuthLoader` | `@clerk/react-router/server` |
 | `clerkMiddleware` | `@clerk/react-router/server` |
-| `ClerkApp` | `@clerk/react-router` |
+| `ClerkProvider` | `@clerk/react-router` |
 | `useAuth`, `useUser` | `@clerk/react-router` |
 | `OrganizationSwitcher` | `@clerk/react-router` |
 

--- a/skills/frameworks/clerk-react-router-patterns/evals/evals.json
+++ b/skills/frameworks/clerk-react-router-patterns/evals/evals.json
@@ -3,14 +3,16 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "i'm building a react router v7 app and need to add clerk authentication. show me how to set up rootAuthLoader and ClerkApp in root.tsx, plus the middleware so getAuth works in nested loaders.",
-      "expected_output": "Sets up rootAuthLoader in root.tsx loader, wraps default export with ClerkApp, exports clerkMiddleware as middleware",
+      "prompt": "i'm building a react router app and need to add clerk authentication. show me how to set up rootAuthLoader and ClerkProvider in root.tsx, plus the middleware so getAuth works in nested loaders.",
+      "expected_output": "Sets up rootAuthLoader in root.tsx loader, renders ClerkProvider with loaderData in the default export, exports clerkMiddleware as middleware, adds ssr.noExternal for @clerk/react-router to vite.config.ts",
       "scaffold": "react-router-basic-auth",
       "expectations": [
         "Calls rootAuthLoader(args) inside the root.tsx loader function",
-        "Wraps the root component with ClerkApp from @clerk/react-router",
+        "Renders <ClerkProvider loaderData={loaderData}> inside the root.tsx default export",
+        "Does NOT use a ClerkApp HOC (it does not exist in @clerk/react-router)",
         "Exports middleware array with clerkMiddleware() from @clerk/react-router/server",
         "Imports rootAuthLoader and clerkMiddleware from @clerk/react-router/server",
+        "Adds ssr: { noExternal: ['@clerk/react-router'] } to vite.config.ts (template uses React Router v8)",
         "Does NOT use @clerk/nextjs imports"
       ]
     },

--- a/skills/frameworks/clerk-react-router-patterns/templates/react-router-basic-auth/package.json
+++ b/skills/frameworks/clerk-react-router-patterns/templates/react-router-basic-auth/package.json
@@ -7,14 +7,14 @@
     "build": "react-router build"
   },
   "dependencies": {
-    "react": "latest",
-    "react-dom": "latest",
-    "react-router": "latest",
-    "@clerk/react-router": "latest"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.0.0",
+    "@clerk/react-router": "^3.5.5"
   },
   "devDependencies": {
-    "@react-router/dev": "latest",
-    "@react-router/node": "latest",
-    "vite": "latest"
+    "@react-router/dev": "^8.0.0",
+    "@react-router/node": "^8.0.0",
+    "vite": "^8.0.0"
   }
 }

--- a/skills/frameworks/clerk-react-router-patterns/templates/react-router-basic-auth/react-router.config.ts
+++ b/skills/frameworks/clerk-react-router-patterns/templates/react-router-basic-auth/react-router.config.ts
@@ -1,7 +1,5 @@
 import type { Config } from '@react-router/dev/config'
 
 export default {
-  future: {
-    v8_middleware: true,
-  },
+  ssr: true,
 } satisfies Config

--- a/skills/frameworks/clerk-react-router-patterns/templates/react-router-basic-auth/vite.config.ts
+++ b/skills/frameworks/clerk-react-router-patterns/templates/react-router-basic-auth/vite.config.ts
@@ -3,4 +3,11 @@ import { defineConfig } from "vite"
 
 export default defineConfig({
 	plugins: [reactRouter()],
+	// React Router v8 dev SSR externalizes @clerk/react-router, which then resolves
+	// react-router's production build while the app uses the development build —
+	// two Router contexts, and useNavigate() throws inside ClerkProvider.
+	// See https://github.com/remix-run/react-router/issues/15232
+	ssr: {
+		noExternal: ["@clerk/react-router"],
+	},
 })


### PR DESCRIPTION
## Summary

React Router 8 shipped on 2026-06-17 and broke `clerk-react-router-patterns` (last touched 2026-05-13) badly enough that a user publicly [couldn't one-shot a Clerk app](https://x.com/Compurnicus/status/2073828066649117008) *with the skill installed*. Root-caused against a live reproduction; this updates the skill for v7 **and** v8.

## What was broken

1. **The skill taught a nonexistent API.** The canonical `root.tsx` imported a `ClerkApp` HOC from `@clerk/react-router`. That export has never existed in this SDK (it was the `@clerk/remix` API) — full git history and changelog of clerk/javascript confirm. Agents following the skill hit an immediate build error and improvise.
2. **`latest` drifted under the skill.** The template pinned `react-router: "latest"`, which flipped from v7 to v8 on June 17 while the template config still set the `future.v8_middleware` flag that v8 removed.
3. **Missing the React Router 8 dev SSR workaround.** RR8 ships development/production conditional exports; `react-router dev` externalizes `@clerk/react-router` for SSR, so it resolves react-router's *production* build while app code gets the *development* build — two module instances, two Router contexts, and every request 500s with `useNavigate() may be used only in the context of a <Router> component.` (upstream: remix-run/react-router#15232). The workaround (`ssr: { noExternal: ['@clerk/react-router'] }`) exists in the [clerk-docs quickstart](https://clerk.com/docs/getting-started/quickstart?framework=react-router) and in clerk/javascript's integration template (added in clerk/javascript#8972), but not in anything agents consume.

## Changes

- `SKILL.md`: replace `ClerkApp` with the real `<ClerkProvider loaderData={loaderData}>` pattern; add a v7 vs v8 config matrix; add the `ssr.noExternal` workaround with the verbatim error string and a warning that `npm ls react-router` showing a single copy does **not** rule out the dual-instance cause (that diagnostic is exactly what misled the agent in the field report); expand the pitfalls table; bump to 1.1.0.
- Template: pin to `react-router@^8`, `react@^19.2.7`, `vite@^8`, `@clerk/react-router@^3.5.5` (the exact combination verified below); drop the removed `v8_middleware` flag; add the `noExternal` workaround with an explanatory comment.
- Evals: eval #1 asserted the nonexistent `ClerkApp` import — rewritten to expect `ClerkProvider` + the vite workaround, and to fail if `ClerkApp` reappears.

## Verification

Reproduced end-to-end in a scratch app (`create-react-router@latest` → RR 8.0.0, `@clerk/react-router@3.5.5`, wired per the docs quickstart):

- Without the workaround: every request 500s in dev; stack trace shows Clerk calling `react-router/dist/production/lib/hooks.js` while the app renders through the development build.
- With `ssr: { noExternal: ['@clerk/react-router'] }`: HTTP 200, clean render.
- `react-router build` also succeeds with the flag applied unconditionally.

## References

- Field report: https://x.com/Compurnicus/status/2073828066649117008
- Upstream issue: https://github.com/remix-run/react-router/issues/15232
- SDK v8 support: https://github.com/clerk/javascript/pull/8972
- Companion PRs: clerk/cli (scaffold the workaround in `clerk init`) and clerk/clerk-docs (add the error string to the quickstart callout) — links in comments once all are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
