### PR TITLE
Rename "Client Trust" to "Device Trust" in skill content

### DIFF
--- a/skills/core/clerk-cli/references/recipes.md
+++ b/skills/core/clerk-cli/references/recipes.md
@@ -94,7 +94,7 @@ clerk users create -d '{
 
 When signing in as either user in a browser or Playwright, enter `424242` at the OTP prompt.
 
-These patterns only apply to development instances. In production, client trust blocks sign-in regardless of suffix or number, and using real-looking test addresses is highly discouraged. Test addresses and numbers do not count against the dev-instance monthly caps (20 SMS, 100 emails). See [Clerk's test emails and phones reference](https://clerk.com/docs/guides/development/testing/test-emails-and-phones) for the full contract.
+These patterns only apply to development instances. In production, Device Trust blocks sign-in regardless of suffix or number, and using real-looking test addresses is highly discouraged. Test addresses and numbers do not count against the dev-instance monthly caps (20 SMS, 100 emails). See [Clerk's test emails and phones reference](https://clerk.com/docs/guides/development/testing/test-emails-and-phones) for the full contract.
 
 ## Organizations
 

--- a/skills/core/clerk-custom-ui/core-3/custom-sign-in.md
+++ b/skills/core/clerk-custom-ui/core-3/custom-sign-in.md
@@ -114,7 +114,7 @@ const { error } = await signIn.resetPasswordEmailCode.submitPassword({
 })
 ```
 
-## Client Trust
+## Device Trust
 
 When a user signs in with a valid password from a new device without MFA enabled, the sign-in status becomes `needs_client_trust`. This requires an additional verification step:
 

--- a/skills/mobile/clerk-expo/evals/evals.json
+++ b/skills/mobile/clerk-expo/evals/evals.json
@@ -56,7 +56,7 @@
     {
       "id": 5,
       "prompt": "build a custom email/password sign in screen for my expo app with clerk, i don't want the prebuilt UI",
-      "expected_output": "Custom flow with the current API: signIn.password({ emailAddress, password }), errors.fields for display, fetchStatus to disable the button, finalize on complete, MFA/client-trust branches handled",
+      "expected_output": "Custom flow with the current API: signIn.password({ emailAddress, password }), errors.fields for display, fetchStatus to disable the button, finalize on complete, MFA/Device Trust branches handled",
       "expectations": [
         "Destructures { signIn, errors, fetchStatus } from useSignIn()",
         "Calls signIn.password({ emailAddress, password }) and checks the returned error",


### PR DESCRIPTION
Part of [PROT-875](https://linear.app/clerk/issue/PROT-875/fully-rename-client-trust-to-device-trust). Independent — no ordering constraint.

Clerk renamed the customer-facing feature "Client Trust" → "Device Trust". This repo was flagged by @manovotny while reviewing clerk/clerk#3051: the renamed guide at `/docs/guides/secure/device-trust` explicitly tells agents to install these skills, so leaving the old name here means the docs and the skills disagree.

## Changes — copy only, 2 lines

- `skills/core/clerk-custom-ui/core-3/custom-sign-in.md` — the `## Client Trust` section heading
- `skills/core/clerk-cli/references/recipes.md` — one sentence of prose

## Not changed

The `needs_client_trust` status value is untouched, here and everywhere else in the rename. Per Kyle in [the naming thread](https://clerkinc.slack.com/archives/C081A8SDN9F/p1784045836197369): _"we don't have to change APIs but the way we discuss clients externally should flip to devices."_ The code sample in `custom-sign-in.md` still checks `signIn.status === 'needs_client_trust'`, which remains correct.

## Related

- clerk/clerk#3051 — docs + marketing rename
- clerk/dashboard#9839 — dashboard UI labels
- clerk/javascript#9266 — SDK doc strings
- clerk/clerk_go#20787 — API descriptions and admin log copy