### PR TITLE
feat(clerk-mosaic): add a skill for styling Mosaic components

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,7 @@
         "./skills/core/clerk-cli",
         "./skills/core/clerk-setup",
         "./skills/core/clerk-custom-ui",
+        "./skills/core/clerk-mosaic",
         "./skills/core/clerk-backend-api"
       ]
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # Clerk Skills
 
-AI agent skills for Clerk authentication. 20 public skills across 4 categories, plus internal maintenance skills under `.agents/skills/`.
+AI agent skills for Clerk authentication. 21 public skills across 4 categories, plus internal maintenance skills under `.agents/skills/`.
 
 ## Structure
 
 ```
 skills/
-├── core/                          # clerk, cli, setup, custom-ui, backend-api
+├── core/                          # clerk, cli, setup, custom-ui, mosaic, backend-api
 ├── frameworks/            # nextjs, react, vue, nuxt, astro, tanstack, react-router, chrome-extension
 ├── features/                      # orgs, webhooks, testing
 └── mobile/                 # swift, android, expo

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ git clone https://github.com/clerk/skills ~/.claude/skills/clerk
 | `clerk-cli` | Clerk CLI operations | Users, orgs, apps, env keys, deploy checks |
 | `clerk-setup` | Add Clerk to any framework | New projects, framework setup |
 | `clerk-custom-ui` | Custom sign-in/up and appearance | Building custom forms, styling |
+| `clerk-mosaic` | Styling Mosaic components with CSS | Theming `--cl-*` tokens and `.cl-*` slots (experimental) |
 | `clerk-backend-api` | Backend REST API explorer | Browsing or calling API endpoints |
 
 ### Framework Patterns
@@ -119,6 +120,7 @@ CLERK_SECRET_KEY=sk_test_xxx
 | "Add phone SMS auth to my Expo app" | `clerk-expo` |
 | "Add Clerk to my Astro site" | `clerk-astro-patterns` |
 | "Build custom sign-in form" | `clerk-custom-ui` |
+| "Match Clerk's UserButton to our design system" | `clerk-mosaic` |
 | "Sync users to Prisma via webhooks" | `clerk-webhooks` |
 | "Add Playwright tests for auth" | `clerk-testing` |
 | "Set up organizations for my B2B app" | `clerk-orgs` |
@@ -144,6 +146,7 @@ clerk-skills/
 │   │   ├── clerk-cli/              # CLI operations
 │   │   ├── clerk-setup/            # Framework setup
 │   │   ├── clerk-custom-ui/        # Component customization
+│   │   ├── clerk-mosaic/           # Mosaic CSS theming
 │   │   └── clerk-backend-api/      # REST API explorer
 │   ├── frameworks/
 │   │   ├── clerk-nextjs-patterns/

--- a/skills/core/clerk-mosaic/SKILL.md
+++ b/skills/core/clerk-mosaic/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: clerk-mosaic
+description: Style Clerk's Mosaic components (experimental) from your own CSS - design
+  token variables, slot classes, cascade layers, dark mode. Use when restyling,
+  rebranding, or theming Mosaic components to match a design system - colors, radius,
+  spacing, fonts, hover and focus states, or targeting one specific element.
+license: MIT
+compatibility: Experimental. Requires `@clerk/nextjs`, `@clerk/react`, or `@clerk/ui` with the `experimental/mosaic` subpath. The surface changes without a major version while experimental.
+metadata:
+  author: clerk
+  version: 0.1.0
+---
+
+# Mosaic
+
+Mosaic components mount directly in your React tree (not in a clerk-js iframe or
+managed root) and ship as a static stylesheet. You style them from your own CSS.
+There is no styling prop and no build step.
+
+```tsx
+import { UserButton } from '@clerk/nextjs/experimental/mosaic';
+```
+
+```css
+@import '@clerk/nextjs/experimental/mosaic/styles.css' layer(clerk);
+```
+
+> Experimental. Components and the styling surface change without a major version.
+
+## The contract
+
+Three hooks are public. Nothing else about the DOM is stable.
+
+| Hook | What it is | Use it for |
+|---|---|---|
+| `--cl-*` variables | Design tokens on `:root` | Color, radius, spacing, type, motion across everything |
+| `.cl-<slot>` classes | One stable class per public element | One specific element |
+| `data-<axis>` attributes | Variant reflection on that element | One specific variant of that element |
+
+```css
+/* token: every button, badge, and link at once */
+:root { --cl-color-primary: light-dark(#6c47ff, #a68cff); }
+
+/* slot + variant: only filled primary buttons */
+.cl-button[data-variant='filled'][data-color='primary'] { font-weight: 600; }
+```
+
+The hashed `x1a2b3c…` classes next to the `.cl-*` one are StyleX internals. Never
+target them.
+
+## Which hook
+
+- Brand color, radius, spacing, or font across the UI → **token**. Start here.
+  One line covers most requests. See `references/variables.md`.
+- Dark mode → flip `color-scheme`, don't re-declare colors. See
+  `references/variables.md`.
+- A token doesn't reach the exact element or variant → **slot class**, narrowed
+  with a `data-*` attribute. See `references/overrides.md`.
+- Hover, focus, active → slot class, but match Clerk's own gating. See
+  `references/overrides.md`.
+
+## References
+
+- `references/setup.md` — the stylesheet import, cascade layers and precedence,
+  isolating your app root so popups paint correctly.
+- `references/variables.md` — the `--cl-*` token catalog, `light-dark()` colors,
+  dark mode, the spacing scale, scoping tokens to a subtree.
+- `references/overrides.md` — slot classes, the `data-<axis>` catalog per
+  component, interaction states, what is not a contract.
+
+## Rules
+
+- Style in CSS. There is no `appearance` or styling prop on Mosaic components —
+  never introduce one to answer a styling request.
+- Prefer a token override to a slot override when both work. It is more durable
+  and covers more surface.
+- Target only `.cl-*` classes and their `data-*` attributes.
+- Override a color token with a `light-dark(<light>, <dark>)` pair, not a flat
+  color, unless you deliberately want one color in both schemes.
+- Wrap `:hover` in `@media (hover: hover)`. Apply `:focus-visible` and `:active`
+  directly.

--- a/skills/core/clerk-mosaic/references/overrides.md
+++ b/skills/core/clerk-mosaic/references/overrides.md
@@ -1,0 +1,187 @@
+# Slot class overrides
+
+When a token doesn't reach the exact element you want, target its slot class.
+
+Every public element carries a stable `.cl-<slot>` class, and its visual props
+are reflected as `data-<axis>` attributes on that same element. So you target an
+element with a class and a variant with an attribute selector — no compound
+class names to memorize.
+
+```css
+/* every button */
+.cl-button {
+  font-weight: 600;
+}
+
+/* only the filled primary variant */
+.cl-button[data-variant='filled'][data-color='primary'] {
+  background-image: linear-gradient(to bottom, #7c5cff, #6c47ff);
+}
+
+/* only the small size */
+.cl-button[data-size='sm'] {
+  letter-spacing: 0.01em;
+}
+```
+
+Reach for this after tokens, not before. A token override survives internal
+restructuring; a slot override is pinned to one element.
+
+## Boolean variants are presence attributes
+
+A boolean reflects only when true, as an empty-string attribute:
+
+```css
+.cl-button[data-full-width] { … }
+.cl-button[data-disabled]   { … }
+.cl-input[data-disabled]    { … }
+```
+
+Multi-word axes are kebab-cased: `fullWidth` → `data-full-width`.
+
+## Slot catalog
+
+| Slot | Element | Variant attributes |
+|---|---|---|
+| `.cl-button` | Button | `data-color` `primary｜neutral｜negative`, `data-variant` `filled｜outline｜ghost｜link`, `data-size` `sm｜md｜lg`, `data-shape` `default｜square｜circle`, `data-full-width`, `data-disabled` |
+| `.cl-button-content` | Text run inside a button | — |
+| `.cl-avatar` | Avatar root | `data-shape` `circle｜square`, `data-size` `fit｜xs｜sm｜md｜lg` |
+| `.cl-avatar-image` | The `<img>` | — |
+| `.cl-avatar-fallback` | Initials shown before/instead of the image | — |
+| `.cl-badge` | Badge | `data-color` `primary｜neutral｜warning｜negative｜positive` |
+| `.cl-card-root` | Card | `data-alignment` `start｜center`, `data-elevation` `card｜flush｜overlay` |
+| `.cl-card-header` / `.cl-card-content` / `.cl-card-footer` | Card regions | — |
+| `.cl-heading` | Heading | `data-size` `xs｜sm｜base｜lg｜xl｜2xl`, `data-color` `primary｜neutral｜warning｜negative｜positive` |
+| `.cl-text` | Body copy | same axes as `.cl-heading` |
+| `.cl-input` | Text input | `data-size` `sm｜md｜lg`, `data-disabled` |
+| `.cl-icon` | Icon | `data-size` `sm｜md｜lg`, `data-placement` `inline-start｜inline-end` |
+| `.cl-spinner` | Loading spinner | `data-size` `sm｜md` |
+| `.cl-item` | List row | `data-size` `xs｜md`, `data-interactive` |
+| `.cl-item-media` / `.cl-item-content` / `.cl-item-title` / `.cl-item-description` / `.cl-item-label` / `.cl-item-actions` | Row regions | — |
+| `.cl-item-group` / `.cl-item-separator` | Row grouping | — |
+| `.cl-menu-trigger` | The element that opens a menu | — |
+| `.cl-menu-positioner` | Portalled wrapper that positions the menu | — |
+| `.cl-menu-popup` | The menu surface | — |
+| `.cl-menu-item` | A menu row | `data-color` `neutral｜negative` |
+| `.cl-menu-separator` | Divider between menu groups | — |
+| `.cl-popover-trigger` | The element that opens a popover | — |
+| `.cl-popover-positioner` | Portalled wrapper that positions the popover | — |
+| `.cl-popover-popup` | The popover surface | — |
+
+Inspect the element in devtools to confirm its slot and the `data-*` attributes
+actually present — a variant at its default value still reflects, a boolean at
+`false` does not.
+
+## Positioner vs popup
+
+`-positioner` is the portalled, fixed-position wrapper. `-popup` is the visible
+box inside it.
+
+- Restyling the surface (background, radius, shadow, padding) → `-popup`.
+- Anything about placement or stacking → usually not yours to set. Positioning is
+  applied inline by the headless positioner, and the popup animates from
+  `--cl-transform-origin`, which the positioner sets. Overriding `transform` or
+  `inset` there fights the positioner.
+
+```css
+.cl-menu-popup {
+  border-radius: 12px;
+  box-shadow: 0 16px 32px -8px rgb(0 0 0 / 0.18);
+}
+```
+
+If a popup is painting *behind* page content, that is a stacking problem, not a
+styling one. See `setup.md` → "Isolate your app root". Adding `z-index` to the
+positioner is the wrong fix.
+
+## Interaction states
+
+### Hover must be gated
+
+Do not write a bare `.cl-button:hover`. Mosaic gates its own hover paints behind
+`@media (hover: hover)` so they don't stick on touchscreens — on a phone,
+`:hover` fires on tap and stays applied until you tap elsewhere. An ungated
+override also outranks Mosaic's gated `:active`, so the press state stops
+showing.
+
+```css
+@media (hover: hover) {
+  .cl-button[data-variant='filled'][data-color='primary']:hover {
+    background-color: #49247a;
+  }
+}
+```
+
+### Focus and active are not gated
+
+Apply them directly.
+
+```css
+.cl-button:focus-visible {
+  outline: 2px solid var(--cl-color-primary);
+  outline-offset: 2px;
+}
+
+.cl-button:active {
+  transform: translateY(1px);
+}
+```
+
+Prefer `:focus-visible` over `:focus`. `:focus` fires on mouse clicks and taps
+too, leaving a ring stuck on the button after a pointer interaction.
+`:focus-visible` shows it only when the browser judges it useful — keyboard and
+other non-pointer navigation — which is what Mosaic's own components do. Reserve
+`:focus` for the rare case where you want a ring on every interaction.
+
+Rule of thumb: `:hover` → wrap in `@media (hover: hover)`. Everything else →
+apply directly.
+
+## Scoping an override
+
+Slot classes are global. Narrow with an ancestor when you want one instance
+styled differently:
+
+```css
+.sidebar .cl-button[data-variant='ghost'] {
+  justify-content: flex-start;
+}
+```
+
+Often a scoped *token* is the better answer — it reaches every element in the
+subtree instead of the one you named:
+
+```css
+.sidebar {
+  --cl-color-primary: light-dark(#0f9d58, #34d399);
+}
+```
+
+## Setting a variable on a slot
+
+The two hooks compose. A `--cl-*` set on a slot class applies to that element
+and its descendants, which is the cleanest way to retheme one component:
+
+```css
+.cl-menu-popup {
+  --cl-color-card: light-dark(#fafafa, #171717);
+  --cl-radius-md: 0.25rem;
+}
+```
+
+Prefer this to redeclaring the popup's `background-color` — anything inside that
+also reads `--cl-color-card` stays consistent.
+
+## What is not a contract
+
+- **The hashed `x1a2b3c…` classes.** StyleX internals. They change on every
+  build. Never target them, never match on them, never mention them in a
+  selector.
+- **DOM structure.** Element nesting, wrappers, and which slot is a child of
+  which can change. Prefer a direct `.cl-<slot>` selector over a descendant
+  chain that encodes structure.
+- **`@layer priority1 … priorityN`.** StyleX's internal precedence layers. Order
+  Clerk's stylesheet with your own outer layer name at import instead — see
+  `setup.md`.
+- **`!important`.** Almost never needed. Unlayered CSS already beats Clerk's
+  layered rules. If a rule isn't applying, the cause is usually layer order or a
+  more specific Clerk selector, not weight.

--- a/skills/core/clerk-mosaic/references/setup.md
+++ b/skills/core/clerk-mosaic/references/setup.md
@@ -1,0 +1,108 @@
+# Setup
+
+Three things: import the stylesheet, decide where it sits in your cascade, and
+give your app root its own stacking context.
+
+## Import the stylesheet
+
+Mosaic components carry no runtime style injection. The stylesheet holds the
+token defaults and every component rule, so nothing renders correctly without
+it. Import it once, at your app's CSS entry point.
+
+Match the subpath to the package you import components from:
+
+```css
+@import '@clerk/nextjs/experimental/mosaic/styles.css';
+@import '@clerk/react/experimental/mosaic/styles.css';
+@import '@clerk/ui/experimental/mosaic/styles.css';
+```
+
+A JS import works too, where your bundler supports it:
+
+```ts
+import '@clerk/nextjs/experimental/mosaic/styles.css';
+```
+
+Prefer the CSS `@import`. It is the only form that can name a cascade layer.
+
+## Cascade layers
+
+Mosaic's internal precedence already lives in layers — StyleX emits
+`@layer priority1 … priorityN` for its own atom ordering. Those are internal.
+What you control is the *outer* layer the whole stylesheet lands in, named at
+import:
+
+```css
+@import '@clerk/nextjs/experimental/mosaic/styles.css' layer(clerk);
+```
+
+Layered styles lose to unlayered ones, so any rule in a plain stylesheet already
+beats Clerk. You rarely need to think about specificity.
+
+To order Clerk against other layers, declare the order first. Later layers win:
+
+```css
+@layer clerk, components, utilities;
+
+@import '@clerk/nextjs/experimental/mosaic/styles.css' layer(clerk);
+```
+
+Now `components` and `utilities` override Clerk, and unlayered rules still beat
+all three.
+
+### With Tailwind
+
+Tailwind v4 declares its own layers. Put Clerk before `utilities` so utility
+classes on a Mosaic component win:
+
+```css
+@layer clerk;
+@import '@clerk/nextjs/experimental/mosaic/styles.css' layer(clerk);
+@import 'tailwindcss';
+```
+
+Importing without a layer also works — Clerk's rules are then unlayered and
+outrank Tailwind's utilities, which is usually not what you want.
+
+## Isolate your app root
+
+Popups (the UserButton menu, popovers) portal to `document.body` and set no
+`z-index` of their own. They rely on being late in DOM order and fixed
+positioned, which is enough until a page element creates a high stacking
+context and paints over them.
+
+Give your app's root element its own stacking context so your page's `z-index`
+values are contained and can't reach past it:
+
+```css
+.root {
+  isolation: isolate;
+}
+```
+
+`isolation: isolate` creates a stacking context without changing layout or
+paint. Every `z-index` inside `.root` is then resolved against the root's own
+level, so a `z-index: 9999` sticky header competes with its siblings rather
+than with the portalled popup.
+
+Apply it to the element that wraps your page content — the one that is a sibling
+of the portal target, not an ancestor of it:
+
+```tsx
+// app/layout.tsx
+<body>
+  <div className='root'>{children}</div>
+</body>
+```
+
+Do not put it on `<body>` or `<html>`. The portal mounts inside `<body>`, so
+isolating there puts the popup in the same stacking context as the content it
+needs to paint above.
+
+## Verify
+
+- The UserButton renders with a border, radius, and spacing → stylesheet is
+  loaded.
+- Its menu opens above your header and sticky elements → root is isolated.
+- A `:root { --cl-color-primary: red }` rule turns the primary button red →
+  layers are ordered such that your CSS wins.

--- a/skills/core/clerk-mosaic/references/variables.md
+++ b/skills/core/clerk-mosaic/references/variables.md
@@ -1,0 +1,251 @@
+# Design token variables
+
+Every visual decision in Mosaic reads from a `--cl-*` custom property. The
+stylesheet declares the defaults on `:root`; you override them the same way you
+would any CSS variable. No rebuild, no prop.
+
+```css
+:root {
+  --cl-color-primary: light-dark(#6c47ff, #a68cff);
+  --cl-radius-md: 0.5rem;
+  --cl-spacing: 0.25rem;
+}
+```
+
+Start here for any request phrased as "match our brand", "our buttons are more
+rounded", "tighter", "our font". One declaration reaches every component.
+
+## Colors are `light-dark()` pairs
+
+Each color token carries its light and dark value in one declaration:
+
+```css
+--cl-color-primary: light-dark(oklch(0.205 0 0), oklch(0.922 0 0));
+```
+
+Override with a `light-dark(<light>, <dark>)` pair so the token keeps responding
+to the color scheme:
+
+```css
+:root {
+  --cl-color-primary: light-dark(#6c47ff, #a68cff);
+  --cl-color-primary-foreground: light-dark(white, #0a0a0a);
+}
+```
+
+A flat value is legal but pins that color in both schemes:
+
+```css
+/* deliberate: this brand color is the same in light and dark */
+--cl-color-primary: #6c47ff;
+```
+
+Only do that when you mean it. For anything that should adapt, keep the pair.
+
+### Color tokens
+
+Semantic families. Each has a base, a `-foreground` for text on top of it, and
+most have a `-faded` for tinted backgrounds.
+
+| Family | Tokens |
+|---|---|
+| Primary | `--cl-color-primary`, `--cl-color-primary-foreground`, `--cl-color-primary-faded` |
+| Neutral | `--cl-color-neutral`, `--cl-color-neutral-foreground`, `--cl-color-neutral-faded` |
+| Negative | `--cl-color-negative`, `--cl-color-negative-foreground`, `--cl-color-negative-faded` |
+| Positive | `--cl-color-positive`, `--cl-color-positive-foreground`, `--cl-color-positive-faded` |
+| Warning | `--cl-color-warning`, `--cl-color-warning-foreground`, `--cl-color-warning-faded` |
+| Surface | `--cl-color-card`, `--cl-color-card-foreground` |
+| Form | `--cl-color-input`, `--cl-color-input-placeholder` |
+| Lines | `--cl-color-border`, `--cl-color-border-faded` |
+
+`--cl-color-card` is the surface color for cards, menus, and popovers.
+`--cl-color-card-foreground` is the text on them.
+
+## Dark mode
+
+Because every color token is a `light-dark()` pair, you do not write a second
+set of colors. You flip `color-scheme` and the right branch resolves.
+
+The default is `light dark`, so Mosaic follows the OS preference with no work.
+
+To force a mode, set `color-scheme` on any ancestor:
+
+```css
+.root {
+  color-scheme: dark;
+}
+```
+
+With a class-based theme switcher:
+
+```css
+:root { color-scheme: light dark; }
+.dark { color-scheme: dark; }
+.light { color-scheme: light; }
+```
+
+To retint a token rather than pick a mode, override its whole pair:
+
+```css
+:root {
+  --cl-color-primary: light-dark(#5b21b6, #c4b5fd);
+}
+```
+
+## Radius
+
+```css
+--cl-radius-none: 0rem;
+--cl-radius-sm:   0.25rem;
+--cl-radius-md:   0.375rem;   /* the control radius: buttons, inputs, square avatars */
+--cl-radius-lg:   0.5rem;     /* cards, menus, popovers */
+--cl-radius-xl:   0.75rem;
+--cl-radius-full: calc(infinity * 1px);
+```
+
+A plain size scale, so nesting a smaller step inside a larger one reads off the
+name. `--cl-radius-md` is what most requests about "rounder buttons" mean.
+
+```css
+:root {
+  --cl-radius-md: 0.75rem;
+  --cl-radius-lg: 1rem;
+}
+```
+
+## Spacing
+
+`--cl-spacing` is the only spacing property exposed. Every gap, pad, and control
+height derives from it, so overriding it rescales the whole UI's density at
+once:
+
+```css
+:root {
+  --cl-spacing: 0.2rem;   /* denser */
+}
+```
+
+The individual steps are internal — there is no `--cl-spacing-4` to target. Set
+the base, or fall back to a slot override for a single element's padding.
+
+`--cl-target-coarse` (default `2.75rem`) is the floor a control's hit area drops
+to under a coarse pointer. It is deliberately off the spacing scale so that
+rescaling density cannot shrink a touch target. Leave it alone unless you have a
+specific accessibility reason.
+
+## Typography
+
+Size and leading are separate variables per step:
+
+```css
+--cl-text-xs-size: 0.75rem;    --cl-text-xs-leading: calc(1 / 0.75);
+--cl-text-sm-size: 0.875rem;   --cl-text-sm-leading: calc(1.25 / 0.875);
+--cl-text-base-size: 1rem;     --cl-text-base-leading: calc(1.5 / 1);
+--cl-text-lg-size: 1.125rem;   --cl-text-lg-leading: calc(1.75 / 1.125);
+--cl-text-xl-size: 1.25rem;    --cl-text-xl-leading: calc(1.75 / 1.25);
+--cl-text-2xl-size: 1.5rem;    --cl-text-2xl-leading: calc(2 / 1.5);
+```
+
+Weights:
+
+```css
+--cl-font-normal: 400;
+--cl-font-medium: 500;
+--cl-font-semibold: 600;
+--cl-font-bold: 700;
+```
+
+Font family defaults to `inherit`, so Mosaic already picks up your app's font.
+Override only to give Clerk a different one:
+
+```css
+:root {
+  --cl-font-family-sans: 'Inter', sans-serif;
+}
+```
+
+## Motion
+
+```css
+--cl-duration-instant: 0s;      /* contact: a press landing, a hover highlight */
+--cl-duration-fast:    0.1s;    /* exits and short pointer-driven change */
+--cl-duration-base:    0.15s;   /* that state decaying after the pointer leaves */
+--cl-duration-slow:    0.25s;   /* panels, overlays */
+--cl-duration-slower:  0.35s;
+
+--cl-ease-default: cubic-bezier(0.175, 0.885, 0.32, 1.1);  /* things arriving */
+--cl-ease-exit:    cubic-bezier(0.55, 0.085, 0.68, 0.53);  /* things leaving */
+```
+
+To cut animation globally, set the durations to `0s`. Prefer letting
+`prefers-reduced-motion` do its job first.
+
+## Scrollbars and edge fades
+
+One opinion for every scrolling surface, applied only under `@media (pointer: fine)`.
+
+```css
+--cl-scrollbar-width: 8px;          /* set to 0px to hide the scrollbar */
+--cl-scrollbar-thumb-inset: 2px;
+--cl-scrollbar-thumb: …;            /* the base; the three below derive from it */
+--cl-scrollbar-thumb-idle: …;       /* pointer elsewhere */
+--cl-scrollbar-thumb-hover: …;
+--cl-scrollbar-thumb-active: …;
+
+--cl-scroll-fade-size:  1.5rem;
+--cl-scroll-fade-range: 1.5rem;
+```
+
+The three state colors derive from `--cl-scrollbar-thumb` at use time, so
+overriding the base re-derives all of them while each stays individually
+overridable.
+
+A scrollbar that fades in on approach:
+
+```css
+:root {
+  --cl-scrollbar-thumb-idle: oklch(from var(--cl-scrollbar-thumb) l c h / 0);
+}
+```
+
+## Scoping to a subtree
+
+Tokens are ordinary custom properties, so setting one on a wrapper applies it to
+everything inside and nothing outside:
+
+```css
+.checkout-flow {
+  --cl-color-primary: light-dark(#0f9d58, #34d399);
+  --cl-radius-md: 0.25rem;
+}
+```
+
+```tsx
+<div className='checkout-flow'>
+  <UserButton />
+</div>
+```
+
+Useful for a marketing page that themes Clerk differently from the app shell, or
+for a single flow with its own accent.
+
+## Mapping to an existing design system
+
+Point Clerk's tokens at yours rather than duplicating values:
+
+```css
+:root {
+  --cl-color-primary: var(--brand-500);
+  --cl-color-primary-foreground: var(--brand-on-500);
+  --cl-color-card: var(--surface-1);
+  --cl-color-card-foreground: var(--text-1);
+  --cl-color-border: var(--border-subtle);
+  --cl-radius-md: var(--radius-control);
+  --cl-radius-lg: var(--radius-surface);
+  --cl-font-family-sans: var(--font-body);
+}
+```
+
+If your system's variables are already per-scheme (a `.dark` class redefining
+`--brand-500`), a flat `var()` is correct here — the branching happens in your
+tokens, not Clerk's.

--- a/skills/core/clerk/SKILL.md
+++ b/skills/core/clerk/SKILL.md
@@ -53,6 +53,11 @@ All skills are written for the current SDK. When something differs in Core 2, it
 - Appearance and styling (themes, colors, layout)
 - `<Show>` component for conditional rendering
 
+**Styling Mosaic components** → Use `clerk-mosaic`
+- `--cl-*` design token variables and `.cl-*` slot classes
+- Stylesheet import, cascade layers, dark mode
+- Experimental: `@clerk/*/experimental/mosaic`
+
 **Advanced Next.js patterns** → Use `clerk-nextjs-patterns`
 - Server vs Client auth APIs
 - Middleware strategies
@@ -145,6 +150,7 @@ If you know your task, you can directly access:
 - `/clerk-setup` - Framework setup
 - `/clerk-cli` - CLI operations and Clerk resource management
 - `/clerk-custom-ui` - Custom flows & appearance
+- `/clerk-mosaic` - Styling Mosaic components (experimental)
 - `/clerk-nextjs-patterns` - Next.js patterns
 - `/clerk-react-patterns` - React patterns
 - `/clerk-react-router-patterns` - React Router patterns


### PR DESCRIPTION
Adds `clerk-mosaic` under `skills/core/`.

Mosaic components (`@clerk/{nextjs,react,ui}/experimental/mosaic`) are styled from the consumer's own CSS. There is no appearance prop. `clerk-custom-ui` covers the prebuilt clerk-js components and their `appearance` API, which is a different surface.

The skill documents the three public hooks and nothing else about the DOM:

- `--cl-*` design token variables
- `.cl-<slot>` classes
- `data-<axis>` variant attributes

Split into three references:

- `setup.md` — the stylesheet import per SDK subpath, naming the outer cascade layer at import, and isolating the app root so portalled popups (which set no `z-index`) can't be painted over.
- `variables.md` — the token catalog, `light-dark()` color pairs, dark mode via `color-scheme` rather than a second set of colors, the single `--cl-spacing` density knob, and mapping the tokens onto an existing design system.
- `overrides.md` — the slot catalog with each component's variant axes, `@media (hover: hover)` gating to match Mosaic's own hover paints, `:focus-visible` over `:focus`, and what is explicitly not a contract (StyleX's hashed `x…` atoms, DOM structure, the internal `priorityN` layers).

Content is derived from `packages/ui/src/mosaic` in `clerk/javascript`: tokens from `tokens.stylex.ts`, slots and variant unions from every `themeProps(...)` call site and the components' props types.

The skill is marked experimental in its frontmatter and description, matching the subpath it documents.

## Checklist

- [x] Skill has `SKILL.md` with YAML frontmatter (`name`, `description`, `license`)
- [x] Placed in the correct category directory (`core`)
- [x] Added to `.claude-plugin/marketplace.json` under the `core` plugin group
- [x] Folder and skill names carry the `clerk-` prefix
- [x] Router skill and README updated

`.agents/plugins/marketplace.json` and `.codex-plugin/plugin.json` bundle the whole `skills/` tree rather than listing skills individually, so neither needed a change.