### PR TITLE
Update README quick start for clerk init

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,20 +100,13 @@ git clone https://github.com/clerk/skills ~/.claude/skills/clerk
 ### 1. Ask Your Agent to Add Clerk
 
 After installing Clerk Skills, ask your coding agent to add Clerk authentication
-to your app. For setup requests, the `clerk-setup` skill should start with:
+to your app. The [`clerk-setup`](skills/core/clerk-setup/SKILL.md#agent-first-provision-via-cli)
+skill covers three paths: a new project and Clerk app, an existing project and
+Clerk app, or a new Clerk app for an existing project.
 
-```bash
-npx -y clerk@latest init
-```
-
-`clerk init` can start without a Clerk account or browser login when
-`clerk-setup` runs as an unauthenticated agent on a framework that supports
-accountless development keys and there is no `--app` or existing project link.
-In that path, it creates an unclaimed development application, writes temporary
-keys to the app's env file, and leaves a local claim breadcrumb so
-`clerk auth login` can connect it to a Clerk account later. If the framework
-requires real API keys, provide an app with `--app <id>` or link the project
-first.
+For a new project, `clerk init` can start without a Clerk account or browser
+login. See [Scenario A: Getting started without an account](skills/core/clerk-setup/SKILL.md#getting-started-without-an-account)
+for how temporary keys and later account claiming work.
 
 ### 2. Example Requests
 

--- a/README.md
+++ b/README.md
@@ -97,16 +97,25 @@ git clone https://github.com/clerk/skills ~/.claude/skills/clerk
 
 ## Quick Start
 
-### 1. Set Up API Keys
+### 1. Ask Your Agent to Add Clerk
 
-Get your keys from the [Clerk Dashboard](https://dashboard.clerk.com/) and add them to `.env`:
+After installing Clerk Skills, ask your coding agent to add Clerk authentication
+to your app. For setup requests, the `clerk-setup` skill should start with:
 
 ```bash
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx
-CLERK_SECRET_KEY=sk_test_xxx
+npx -y clerk@latest init
 ```
 
-### 2. Ask Your Agent
+`clerk init` can start without a Clerk account or browser login when
+`clerk-setup` runs as an unauthenticated agent on a framework that supports
+accountless development keys and there is no `--app` or existing project link.
+In that path, it creates an unclaimed development application, writes temporary
+keys to the app's env file, and leaves a local claim breadcrumb so
+`clerk auth login` can connect it to a Clerk account later. If the framework
+requires real API keys, provide an app with `--app <id>` or link the project
+first.
+
+### 2. Example Requests
 
 | You Say | Skill Used |
 |---------|------------|

--- a/skills/core/clerk-setup/SKILL.md
+++ b/skills/core/clerk-setup/SKILL.md
@@ -28,6 +28,8 @@ clerk init --framework <next|react|vue|nuxt|astro|react-router|tanstack-react-st
 
 `clerk init` installs the SDK, wires the project up, and writes the framework-specific publishable + secret keys to the right env file (e.g. `.env.local` for Next.js, `.env` for Vite-based projects).
 
+#### Getting started without an account
+
 **No login required.** Unauthenticated, `clerk init` writes temporary development keys to the project's env file — no account, no browser, no flag. Don't run `clerk auth login` first. Authenticated (or with `--app` / `--login`) it creates and links a real app via PLAPI instead.
 
 `--template <b2b-saas|b2c-saas|native|waitlist>` pre-configures the temporary app. Caveats — a signed-out human in an *existing* project still gets the login flow unless they pass `--keyless`; `--template`/`--fresh` error on any run that targets a real app; login only auto-claims what `clerk init` created. See [clerk-cli](../clerk-cli/references/auth.md#accountless-operating-without-an-account).


### PR DESCRIPTION
## Summary

- replace the Dashboard-key-first README setup with a link to the agent-first clerk-setup workflow
- keep the detailed accountless setup guidance in Scenario A of the skill
- add a direct README link to the new Getting started without an account subsection

## Checks

- git diff --check
- skill validator could not run locally because its Python environment is missing PyYAML; frontmatter was unchanged