### PR TITLE
fix(clerk-orgs): use inline query strings instead of a --query flag

### DIFF
--- a/skills/features/clerk-orgs/SKILL.md
+++ b/skills/features/clerk-orgs/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY. Organizations must be enabled in Clerk Dashboard → Organizations. Membership mode (required vs optional) must match the B2B vs B2C + B2B coexistence story of your app.
 metadata:
   author: clerk
-  version: 3.1.0
+  version: 3.1.1
 ---
 
 # Organizations (B2B SaaS)
@@ -79,7 +79,7 @@ clerk api -X POST /v1/organizations \
   -d '{"name":"Acme","slug":"acme","created_by":"user_xxx","max_allowed_memberships":10}'
 
 # List:
-clerk api /v1/organizations --query 'limit=20'
+clerk api '/v1/organizations?limit=20'
 
 # Get one:
 clerk api /v1/organizations/<org_id>
@@ -99,7 +99,7 @@ clerk api -X POST /v1/organizations/<org_id>/memberships \
   -d '{"user_id":"user_xxx","role":"org:admin"}'
 
 # List members:
-clerk api /v1/organizations/<org_id>/memberships --query 'limit=50'
+clerk api '/v1/organizations/<org_id>/memberships?limit=50'
 
 # Update role:
 clerk api -X PATCH /v1/organizations/<org_id>/memberships/<user_id> \
@@ -117,7 +117,7 @@ clerk api -X POST /v1/organizations/<org_id>/invitations \
   -d '{"email_address":"alice@example.com","role":"org:member","redirect_url":"https://app.com/accept"}'
 
 # List pending:
-clerk api /v1/organizations/<org_id>/invitations --query 'status=pending'
+clerk api '/v1/organizations/<org_id>/invitations?status=pending'
 
 # Revoke:
 clerk api -X POST /v1/organizations/<org_id>/invitations/<inv_id>/revoke \


### PR DESCRIPTION
Three list commands in `clerk-orgs` pass a `--query` flag to `clerk api`. That flag does not exist — `clerk api` takes the endpoint as a path argument and nothing parses a query option. Commander rejects it during argument parsing, before any auth or network work, so these commands fail for everyone regardless of credentials.

```
$ clerk api /v1/organizations --query 'limit=20'
error: unknown option '--query'
$ echo $?
1
```

The fix inlines the query string, matching the form already used in `clerk-cli/references/recipes.md:104`:

```
$ clerk api '/v1/organizations?limit=20' --dry-run
[dry-run] GET https://api.clerk.com/v1/organizations?limit=20
$ echo $?
0
```

All three replacements verified against the published `clerk@3.2.0`, and the query params confirmed against the Backend API: `limit` comes from the shared pagination parser, and `status` is read on the org invitations list endpoint.

The likely origin is `clerk users list`, which does take `--query` — as a search term, not a query string.

Also bumps the skill to 3.1.1 so consumers can tell the broken version apart. Happy to drop that if versioning is handled differently.