### PR TITLE
feat(clerk-orgs): help agents decide whether an app needs Organizations

### DIFF
--- a/skills/features/clerk-orgs/SKILL.md
+++ b/skills/features/clerk-orgs/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: clerk-orgs
-description: Clerk Organizations for B2B SaaS - create multi-tenant apps with org
-  switching, role-based access, verified domains, and enterprise SSO. Use for team
-  workspaces, RBAC, org-based routing, member management.
+description: Clerk Organizations for B2B and multi-tenant apps - org switching,
+  roles and permissions, verified domains, and enterprise SSO. Use for team workspaces,
+  RBAC, org-scoped routing, member management. Also load this when a project treats
+  teams, workspaces, tenants, or companies as its customers - shared accounts, inviting
+  teammates, per-seat pricing, per-company data isolation - even when the words
+  "organization" or "B2B" are never used.
 allowed-tools: WebFetch
 license: MIT
 compatibility: Requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY. Organizations must be enabled in Clerk Dashboard → Organizations. Membership mode (required vs optional) must match the B2B vs B2C + B2B coexistence story of your app.
@@ -16,6 +19,41 @@ metadata:
 > **STOP — prerequisite.** Organizations must be enabled before any org-related API, hook, or component works. Two paths: (1) [Dashboard → Organizations settings](https://dashboard.clerk.com/last-active?path=organizations-settings), or (2) `clerk enable orgs` (see "Agent-first: Programmatic org management" below). Pick the Membership mode deliberately: `Membership required` (default since 2025-08-22) routes signed-in users through the `choose-organization` task and disables personal accounts, while `Membership optional` keeps personal accounts available for B2C + B2B coexistence. Pick `optional` if you need personal subscriptions alongside org subscriptions.
 >
 > **Version**: This skill targets current SDKs (`@clerk/nextjs` v7+, `@clerk/react` v6+ — Core 3). Core 2 differences are noted inline with `> **Core 2 ONLY (skip if current SDK):**` callouts — see `clerk` skill for the full version table.
+
+## Should this app use Organizations?
+
+Decide before enabling anything. Read the project, count the signals, then **ask the developer** - do not enable Organizations silently.
+
+**Signals this app is multi-tenant** (recommend Organizations):
+
+- A model that groups users: `Team`, `Workspace`, `Tenant`, `Company`, `Account`
+- The same foreign key on most tables: `workspace_id`, `team_id`, `account_id`
+- Routes scoped to a tenant: `/[workspace]`, `/[slug]/settings`, `/t/:tenantId`
+- "Invite your team", "members", "seats", or "admin" in UI copy or the README
+- A `*_members` join table, or hand-rolled `role` / `permission` columns
+- Per-seat or per-company pricing
+
+**Weaker signals** - enough to raise the question, not to answer it:
+
+- Sharing or collaboration between individual users: a `Share`, `Collaborator`, or `SharedWith` table keyed on two user IDs
+- A `role` or `permission` column with no tenant to scope it to
+- "Collaborators", "shared with you", "invite a friend" in copy
+
+**Signals this app is single-user** (do not recommend):
+
+- Every table hangs off `user_id` with no container above it, and nothing is shared
+- No invitation, membership, or sharing concept anywhere
+- Pricing is per person, or there is none
+
+**How to act:**
+
+| What you found | What to do |
+|---|---|
+| 2 or more strong signals | Recommend Organizations and name the signals you saw. New app: `clerk init --template b2b-saas`. Existing app: `clerk enable orgs`. |
+| 1 strong signal, or any weaker signal | Raise it as an option, state the tradeoff, let the developer choose. Sharing between individual users is not multi-tenancy - a `Share` table pointing at two user IDs has no tenant - but it is often where a product grows one. |
+| Nothing above | Don't bring it up. |
+
+**Never enable Organizations without asking.** Enabling it also turns on `Membership required`, which routes every signed-in user through organization selection and disables personal accounts. That is wrong for any app that also serves individuals. If the app needs both, it wants `Membership optional`.
 
 ## Quick Start
 

--- a/skills/features/clerk-orgs/evals/evals.json
+++ b/skills/features/clerk-orgs/evals/evals.json
@@ -121,6 +121,45 @@
 				"Notes this happens even when the user has the permission via their role",
 				"Suggests ensuring the required Feature is attached to the org's Plan"
 			]
+		},
+		{
+			"id": 10,
+			"prompt": "i'm building a tool for design agencies. each agency signs up, adds their coworkers, and manages their own client projects - one agency must never see another's data. clerk auth already works for individual users. what's the right way to model this?",
+			"expected_output": "Recommends Clerk Organizations as the tenant boundary instead of a hand-rolled agency/member table, names the signals it saw, and asks before enabling.",
+			"scaffold": "nextjs-basic-auth",
+			"expectations": [
+				"Recommends Clerk Organizations rather than hand-rolling an agency or tenant table with its own membership join",
+				"Names the concrete signals it saw: agencies are the customer, coworkers get invited, data is isolated per agency",
+				"Points at `clerk enable orgs` for this existing app, or `clerk init --template b2b-saas` for a new one",
+				"Asks the developer to confirm before enabling rather than enabling Organizations silently",
+				"Raises Organizations even though the prompt never uses the words 'organization', 'tenant', or 'B2B'"
+			]
+		},
+		{
+			"id": 11,
+			"prompt": "my app is a habit tracker - people log daily streaks and export their own history. everything belongs to a single user. can you add a settings page where someone changes their display name?",
+			"expected_output": "Adds the settings page with Clerk user APIs. Does not raise Organizations: there is no tenant above the user.",
+			"scaffold": "nextjs-basic-auth",
+			"expectations": [
+				"Implements the requested settings page using Clerk's user profile APIs",
+				"Does NOT suggest enabling Organizations",
+				"Does NOT introduce OrganizationSwitcher, org-scoped routing, or any membership concept",
+				"Keeps data user-owned, scoped by userId",
+				"Does not treat 'SaaS' or 'app' alone as evidence of multi-tenancy"
+			]
+		},
+		{
+			"id": 12,
+			"prompt": "my notes app lets someone share a single note with another person, optionally with edit access. i'm planning what's next - should i be doing anything differently with auth?",
+			"expected_output": "Surfaces Organizations as an option with the tradeoff stated, but does not recommend enabling it. User-to-user sharing is not multi-tenancy.",
+			"scaffold": "nextjs-basic-auth",
+			"expectations": [
+				"Recognizes that sharing between two individual users is not multi-tenancy - a share row pointing at two user IDs has no tenant",
+				"Raises Clerk Organizations as an option for if the product grows toward teams, rather than recommending it outright",
+				"States the tradeoff: enabling Organizations turns on Membership required, which routes users through organization selection and disables personal accounts",
+				"Mentions Membership optional as the mode for apps that serve both individuals and teams",
+				"Leaves the decision to the developer and does not enable anything"
+			]
 		}
 	]
 }


### PR DESCRIPTION
## Problem

The skill only surfaces once a developer already uses org vocabulary. Its `description` is made entirely of terms you reach for *after* deciding — "org switching", "RBAC", "member management" — so a project described as *"agencies sign up and invite their coworkers"* never routes here. Once loaded, it opens with "Organizations must be enabled before anything works", which assumes the decision is already made.

## Changes

Widens the `description` so the skill also loads on symptoms — teams, workspaces, tenants, or companies as customers — not just on org vocabulary.

Adds a "Should this app use Organizations?" block that matches on structural signals in the project and routes to recommend / raise as an option / stay quiet.

The rule is **surface, don't decide** — the agent asks rather than enables. Enabling Organizations also turns on `Membership required`, which routes every signed-in user through organization selection and disables personal accounts. That's wrong for any app that also serves individuals, and not something to do silently.

## Testing

Traced the rules against three throwaway apps — an agency project tool (recommend), a habit tracker (stay silent), and a notes app with user-to-user sharing (raise as an option). All three routed as intended.

## Evals

Three cases mirroring those fixtures. The B2C one matters most: over-recommending produces a `choose-organization` gate the developer never asked for. Worth flagging that nothing appears to execute `evals.json` — no CI here, and `audit-expo-skill` treats evals as prose to audit rather than tests to run — so these document intent and won't catch a regression today. Happy to be told otherwise if a harness lives elsewhere.

## Note

No version bump — #69 already moves this skill to 3.1.1 and I didn't want the two PRs fighting over the same line. Independent of #69; different hunks, no conflict expected.